### PR TITLE
Widgets macro

### DIFF
--- a/figuro/meta/signals.nim
+++ b/figuro/meta/signals.nim
@@ -111,18 +111,18 @@ template packResponse*(res: AgentResponse): Variant =
   so
 
 proc getSignalName*(signal: NimNode): NimNode =
-  echo "getSignalName: ", signal.treeRepr
+  # echo "getSignalName: ", signal.treeRepr
   if signal.kind in [nnkClosedSymChoice, nnkOpenSymChoice]:
     result = newStrLitNode signal[0].strVal
   else:
     result = newStrLitNode signal.strVal
-    echo "getSignalName:result: ", result.treeRepr
+    # echo "getSignalName:result: ", result.treeRepr
 
 macro signalName*(signal: untyped): untyped =
   result = getSignalName(signal)
 
 proc splitNamesImpl(slot: NimNode): Option[(NimNode, NimNode)] =
-  echo "splitNamesImpl: ", slot.treeRepr
+  # echo "splitNamesImpl: ", slot.treeRepr
   if slot.kind == nnkCall and slot[0].kind == nnkDotExpr:
     return splitNamesImpl(slot[0])
   elif slot.kind == nnkCall:
@@ -135,7 +135,7 @@ proc splitNamesImpl(slot: NimNode): Option[(NimNode, NimNode)] =
       slot[0].copyNimTree,
       slot[1].copyNimTree,
     )
-  echo "splitNamesImpl:res: ", result.repr
+  # echo "splitNamesImpl:res: ", result.repr
 
 macro signalType*(s: untyped): auto =
   ## gets the type of the signal without 

--- a/figuro/meta/slots.nim
+++ b/figuro/meta/slots.nim
@@ -330,8 +330,8 @@ macro rpcImpl*(p: untyped, publish: untyped, qarg: untyped): untyped =
 
   # echo "slot: "
   # echo result.treeRepr
-  echo "slot:repr:"
-  echo result.repr
+  # echo "slot:repr:"
+  # echo result.repr
 
 template slot*(p: untyped): untyped =
   rpcImpl(p, nil, nil)

--- a/figuro/ui/apis.nim
+++ b/figuro/ui/apis.nim
@@ -8,36 +8,6 @@ import commons, core
 
 export core, cssgrid
 
-# proc defaultLineHeight*(fontSize: UICoord): UICoord =
-#   result = fontSize * defaultlineHeightRatio
-# proc defaultLineHeight*(ts: TextStyle): UICoord =
-#   result = defaultLineHeight(ts.fontSize)
-
-# macro statefulWidget*(p: untyped): untyped =
-#   ## implements a stateful widget template constructors where 
-#   ## the type and the name are taken from the template definition:
-#   ## 
-#   ##    template `name`*[`type`, T](id: string, value: T, blk: untyped) {.statefulWidget.}
-#   ## 
-#   # echo "figuroWidget: ", p.treeRepr
-#   p.expectKind nnkTemplateDef
-#   let name = p.name()
-#   let genericParams = p[2]
-#   let typ = genericParams[0][0]
-#   p.params()[0].expectKind(nnkEmpty) # no return type
-#   if genericParams.len() > 1:
-#     error("incorrect generic types: " & repr(genericParams) & "; " & "Should be `[WidgetType, T]`", genericParams)
-#   if p.params()[1].repr() != "id: string":
-#     error("incorrect arguments: " & repr(p.params()[1]) & "; " & "Should be `id: string`", p.params()[1])
-#   if p.params()[2][1].repr() != genericParams[0][1].repr:
-#     error("incorrect arguments: " & repr(p.params()[2][1]) & "; " & "Should be `" & genericParams[0][1].repr & "`", p.params()[2][1])
-#   if p.params()[3][1].repr() != "untyped":
-#     error("incorrect arguments: " & repr(p.params()[3][1]) & "; " & "Should be `untyped`", p.params()[3][1])
-#   # echo "figuroWidget: ", " name: ", name, " typ: ", typ
-#   # echo "\n"
-#   # echo "doPostId: ", doPostId, " li: ", lineInfo(p.name())
-#   result = quote do:
-#     mkStatefulWidget(`typ`, `name`, doPostId)
 
 proc init*(tp: typedesc[Stroke], weight: float32|UICoord, color: string, alpha = 1.0): Stroke =
   ## Sets stroke/border color.

--- a/figuro/ui/core.nim
+++ b/figuro/ui/core.nim
@@ -269,10 +269,6 @@ proc checkMouseEvents*(node: Figuro): MouseEventFlags =
     node.checkEvent(evRelease, uxInputs.mouse.release())
     node.checkEvent(evOverlapped, true)
     node.checkEvent(evHover, true)
-    # if node.mouseOverlaps():
-    #   result.incl evHover
-    # if uxInputs.mouse.click():
-    #   result.incl evClickOut
 
 type
   EventsCapture*[T: set] = object
@@ -293,7 +289,8 @@ proc maxEvt[T](a, b: EventsCapture[T]): EventsCapture[T] =
   else: a
 
 proc consumeMouseButtons(mouseEvts: MouseEventFlags): array[MouseEventKinds, UiButtonView] =
-  # Consume mouse buttons
+  ## Consume mouse buttons
+  ## 
   if evPress in mouseEvts:
     result[evPress] = uxInputs.buttonPress * MouseButtons
     uxInputs.buttonPress.excl MouseButtons
@@ -315,6 +312,7 @@ proc consumeMouseButtons(mouseEvts: MouseEventFlags): array[MouseEventKinds, UiB
 
 proc computeNodeEvents*(node: Figuro): CapturedEvents =
   ## Compute mouse events
+  ## 
   for n in node.children.reverse:
     let child = computeNodeEvents(n)
     for ek in MouseEventKinds:

--- a/figuro/ui/core.nim
+++ b/figuro/ui/core.nim
@@ -321,12 +321,7 @@ proc computeNodeEvents*(node: Figuro): CapturedEvents =
 
   let
     mouseEvts = node.checkMouseEvents()
-    # mouseOutEvts = allMouseEvts * MouseOnOutEvents
-    # mouseEvts = allMouseEvts
-    # gestureEvts = node.checkGestureEvents()
-
-  let buttons = mouseEvts.consumeMouseButtons()
-  # echo "remove buttons: ", uxInputs.buttonRelease, " node: ", node.getId()
+    buttons = mouseEvts.consumeMouseButtons()
 
   for ek in MouseEventKinds:
     let captured = MouseCapture(zlvl: node.zlevel,

--- a/figuro/ui/core.nim
+++ b/figuro/ui/core.nim
@@ -361,8 +361,6 @@ proc computeEvents*(node: Figuro) =
         target.events.mouse.incl evts.flags
 
   # Mouse
-  # let mouseButtons = uxInputs.buttonRelease * MouseButtons
-  
   printNewEventInfo()
 
   if captured.mouse[evHover].targets != prevHovers:

--- a/figuro/ui/core.nim
+++ b/figuro/ui/core.nim
@@ -168,8 +168,6 @@ proc preNode*[T: Figuro](kind: NodeKind, id: string, current: var T, parent: Fig
   current.name.setLen(0)
   discard current.name.tryAdd(name)
   current.kind = kind
-  # current.textStyle = parent.textStyle
-  # current.cursorColor = parent.cursorColor
   current.highlight = parent.highlight
   current.transparency = parent.transparency
   current.zlevel = parent.zlevel
@@ -179,12 +177,8 @@ proc preNode*[T: Figuro](kind: NodeKind, id: string, current: var T, parent: Fig
 
   nodeStack.add(current)
   inc parent.diffIndex
-
   current.diffIndex = 0
-  # TODO: which is better?
-  # draw(T(current))
 
-  # current.attrs.incl postDrawReady
   connect(current, onDraw, current, Figuro.clearDraw())
   connect(current, onDraw, current, typeof(current).draw())
   connect(current, onDraw, current, Figuro.handlePostDraw())

--- a/figuro/ui/core.nim
+++ b/figuro/ui/core.nim
@@ -199,8 +199,7 @@ template node*(kind: NodeKind, id: string, blk: untyped): untyped =
     var parent: Figuro = current
     var current {.inject.}: Figuro = nil
     preNode(kind, id, current, parent)
-    let x = id
-    captureArgs x:
+    captureArgs id:
       current.postDraw = proc (widget: Figuro) =
         # echo nd(), "node:postDraw: ", widget.getId
         var current {.inject.}: Figuro = widget

--- a/figuro/ui/utils.nim
+++ b/figuro/ui/utils.nim
@@ -4,10 +4,16 @@ import macros
 
 macro captureArgs*(args, blk: untyped): untyped =
   echo "captureArgs: ", args.treeRepr
+  echo "captureArgs: ", args.repr
   result = nnkCommand.newTree(bindSym"capture")
   if args.kind in [nnkSym, nnkIdent]:
     if args.strVal != "void":
       result.add args
+  elif args.kind == nnkObjConstr:
+    for arg in args[1][^1][^1]:
+      echo "arg add: ", arg.repr
+      if arg.strVal != "void":
+        result.add arg
   else:
     for arg in args:
       echo "arg add: ", arg.repr

--- a/figuro/ui/utils.nim
+++ b/figuro/ui/utils.nim
@@ -13,7 +13,7 @@ macro captureArgs*(args, blk: untyped): untyped =
   if result.len() == 0:
     result = nnkEmpty.newNimNode
   result.add nnkStmtList.newTree(blk)
-  echo "captured: ", result.repr
+  # echo "captured: ", result.repr
 
 macro statefulWidgetProc*(): untyped =
   ident(repr(genSym(nskProc, "doPost")))

--- a/figuro/ui/utils.nim
+++ b/figuro/ui/utils.nim
@@ -81,49 +81,6 @@ template withDraw*[T](fig: T, blk: untyped): untyped =
     var current {.inject, used.} = fig
     `blk`
 
-macro widget*(p: untyped): untyped =
-  ## implements a stateful widget template constructors where 
-  ## the type and the name are taken from the template definition:
-  ## 
-  ##    template `name`*[`type`, T](id: string, value: T, blk: untyped) {.statefulWidget.}
-  ## 
-  echo "figuroWidget: ", p.treeRepr
-  echo "figuroWidget: ", p.repr
-
-  p.expectKind nnkTemplateDef
-  let name = p.name()
-  let genericParams = p[2]
-  let typ = genericParams[0][0]
-  echo "genericParams: ", genericParams.treeRepr
-  echo "genericParams: ", genericParams[0][0].treeRepr
-  p.params()[0].expectKind(nnkEmpty) # no return type
-  if genericParams.len() > 1:
-    error("incorrect generic types: " &
-              repr(genericParams) & "; " &
-              "Should be `[WidgetType, T]`",
-          genericParams)
-  if p.params()[1].repr() != "id: string":
-    error("incorrect arguments: " &
-              repr(p.params()[1]) & "; " &
-              "Should be `id: string`",
-          p.params()[1])
-  echo "repr21: ", p.params()[2][1].repr(), " ", genericParams[0][1].repr
-  if p.params()[2][1].repr() != genericParams[0][1].repr:
-    error("incorrect arguments: `" &
-              repr(p.params()[2][1]) & "`; " &
-              "Should be `[WidgetType, T]`",
-          p.params()[2][1])
-  if p.params()[3][1].repr() != "untyped":
-    error("incorrect arguments: " &
-              repr(p.params()[3][1]) & "; " &
-              "Should be `untyped`",
-          p.params()[3][1])
-  # echo "figuroWidget: ", " name: ", name, " typ: ", typ
-  # echo "\n"
-  # echo "doPostId: ", doPostId, " li: ", lineInfo(p.name())
-  result = quote do:
-    mkStatefulWidget(`typ`, `name`, doPostId)
-
 type
   State*[T] = object
   Captures*[V] = object

--- a/figuro/ui/utils.nim
+++ b/figuro/ui/utils.nim
@@ -141,35 +141,3 @@ macro captures*(vals: varargs[untyped]): untyped =
     tpl.add val
   result = quote do:
     Captures[typeof(`tpl`)](val: `tpl`)
-
-template declareStatefulWidget*[Widget](
-  widget: untyped,
-  tp: typedesc[Widget]
-) =
-
-  template `widget`*[T; V](
-      id: string,
-      state: State[T],
-      value: Captures[V],
-      blk: untyped
-  ) =
-    block:
-      var parent: Figuro = Figuro(current)
-      var current {.inject.}: Widget[T] = nil
-      preNode(nkRectangle, id, current, parent)
-      captureArgs value:
-        current.postDraw = proc (self: Figuro) =
-          var current {.inject.}: Widget[T] = Widget[T](self)
-          if postDrawReady in self.attrs:
-            self.attrs.excl postDrawReady
-            `blk`
-      postNode(Figuro(current))
-
-  template `widget`*[V](id: string, value: Captures[V], blk: untyped) =
-    `widget`(id, state(void), value, blk)
-
-  template `widget`*[T](id: string, state: State[T], blk: untyped) =
-    `widget`(id, state, captures(), blk)
-
-  template `widget`*(id: string, blk: untyped) =
-    `widget`(id, state(void), void, blk)

--- a/figuro/ui/utils.nim
+++ b/figuro/ui/utils.nim
@@ -65,8 +65,8 @@ template printNewEventInfo*() =
 
 template withDraw*[T](fig: T, blk: untyped): untyped =
   block:
-    var parent {.inject.} = fig.parent
-    var current {.inject.} = fig
+    var parent {.inject, used.} = fig.parent
+    var current {.inject, used.} = fig
     `blk`
 
 macro widget*(p: untyped): untyped =

--- a/figuro/ui/utils.nim
+++ b/figuro/ui/utils.nim
@@ -63,6 +63,12 @@ template printNewEventInfo*() =
           stdout.styledWrite({styleBright}, " ", fgBlue, n, fgGreen, v)
         stdout.styledWriteLine(fgWhite, "")
 
+template withDraw*[T](fig: T, blk: untyped): untyped =
+  block:
+    var parent {.inject.} = fig.parent
+    var current {.inject.} = fig
+    `blk`
+
 macro widget*(p: untyped): untyped =
   ## implements a stateful widget template constructors where 
   ## the type and the name are taken from the template definition:

--- a/figuro/ui/utils.nim
+++ b/figuro/ui/utils.nim
@@ -114,6 +114,9 @@ proc parseWidgetArgs*(args: NimNode): WidgetArgs =
   result.blk = args[^1]
 
   for arg in args[0..^2]:
+    ## iterate through the widget args looking for 
+    ## `state(int)` or `captures(i, x)` 
+    ## 
     if arg.kind == nnkCall:
       let fname = arg[0]
       if fname.repr == "state":
@@ -151,3 +154,5 @@ proc generateBodies*(widget: NimNode, wargs: WidgetArgs): NimNode =
       preNode(nkRectangle, `id`, current, parent)
       `outer`
       postNode(Figuro(current))
+
+  echo "widget:result:\n", result.repr

--- a/figuro/ui/utils.nim
+++ b/figuro/ui/utils.nim
@@ -155,4 +155,12 @@ proc generateBodies*(widget: NimNode, wargs: WidgetArgs): NimNode =
       `outer`
       postNode(Figuro(current))
 
-  echo "widget:result:\n", result.repr
+  echo "Widget:result:\n", result.repr
+
+template exportWidget*[T](name: untyped, class: typedesc[T]) =
+  ## exports a helper 
+  macro `name`*(args: varargs[untyped]) =
+    let widget = ident(repr `class`)
+    let wargs = args.parseWidgetArgs()
+    result = widget.generateBodies(wargs)
+

--- a/figuro/ui/utils.nim
+++ b/figuro/ui/utils.nim
@@ -108,6 +108,10 @@ type
   ]
 
 proc parseWidgetArgs*(args: NimNode): WidgetArgs =
+  ## Parses widget args looking for options:
+  ## - `state(int)` 
+  ## - `captures(i, x)` 
+  ## 
   args.expectKind(nnkArgList)
 
   result.id = args[0]
@@ -139,13 +143,13 @@ proc generateBodies*(widget: NimNode, wargs: WidgetArgs): NimNode =
           `blk`
 
   let outer =
-    if not capturedVals.isNil:
+    if capturedVals.isNil:
+      quote do:
+        `body`
+    else:
       quote do:
         capture `capturedVals`:
           `body`
-    else:
-      quote do:
-        `body`
 
   result = quote do:
     block:

--- a/figuro/widget.nim
+++ b/figuro/widget.nim
@@ -5,6 +5,7 @@ import meta/slots
 import inputs
 import ui/core
 import ui/apis
+import ui/utils
 
 export signals, slots
-export apis, core, ui, inputs
+export apis, core, ui, inputs, utils

--- a/figuro/widgets/button.nim
+++ b/figuro/widgets/button.nim
@@ -76,13 +76,13 @@ template button*[T](s: State[T] = state(void),
   button(s, name, void, blk)
 
 template button*(name: string,
-                    blk: untyped) =
-  button(state(void), name, void, blk)
+                 value: untyped,
+                 blk: untyped) =
+  button(state(void), name, value, blk)
 
 template button*(name: string,
-                    value: untyped,
-                    blk: untyped) =
-  button(state(void), name, value, blk)
+                 blk: untyped) =
+  button(state(void), name, void, blk)
 
 # import macros
 # macro button*(s, args: varargs[untyped]) =

--- a/figuro/widgets/button.nim
+++ b/figuro/widgets/button.nim
@@ -13,7 +13,8 @@ type
 proc hover*[T](self: Button[T], kind: EventKind) {.slot.} =
   # self.fill = parseHtmlColor "#9BDFFA"
   # echo "button hover!"
-  echo "button:hovered: ", kind, " :: ", self.getId, " buttons: ", self.events.mouse
+  echo "button:hovered: ", kind, " :: ", self.getId,
+          " buttons: ", self.events.mouse
   # if kind == Enter:
   #   self.events.mouse.incl evHover
   # else:
@@ -23,12 +24,14 @@ proc hover*[T](self: Button[T], kind: EventKind) {.slot.} =
 proc clicked*[T](self: Button[T],
                   kind: EventKind,
                   buttons: UiButtonView) {.slot.} =
-  echo nd(), "button:clicked: ", buttons, " kind: ", kind, " :: ", self.getId
+  echo nd(), "button:clicked: ", buttons,
+              " kind: ", kind, " :: ", self.getId
+
   if not self.isActive:
     refresh(self)
   self.isActive = true
 
-proc draw*[T](self: Button[T]) {.slot.} =
+proc draw*[T](self: Button[T]) {.slot, widget.} =
   ## button widget!
   # current = self
   # echo "button:draw"
@@ -47,7 +50,11 @@ proc draw*[T](self: Button[T]) {.slot.} =
 
 import ../ui/utils
 
-template button*[T; V](typ: typedesc[T], name: string, value: V, blk: untyped) =
+
+template button*[T; V](typ: typedesc[T],
+                        name: string,
+                        value: V,
+                        blk: untyped) =
   block:
     var parent: Figuro = Figuro(current)
     var current {.inject.}: Button[T] = nil

--- a/figuro/widgets/button.nim
+++ b/figuro/widgets/button.nim
@@ -31,7 +31,7 @@ proc clicked*[T](self: Button[T],
     refresh(self)
   self.isActive = true
 
-proc draw*[T](self: Button[T]) {.slot, widget.} =
+proc draw*[T](self: Button[T]) {.widget, slot.} =
   ## button widget!
   # current = self
   # echo "button:draw"
@@ -49,7 +49,6 @@ proc draw*[T](self: Button[T]) {.slot, widget.} =
       # this changes the color on hover!
 
 import ../ui/utils
-
 
 template button*[T; V](typ: typedesc[T],
                         name: string,

--- a/figuro/widgets/button.nim
+++ b/figuro/widgets/button.nim
@@ -49,32 +49,4 @@ proc draw*[T](self: Button[T]) {.slot.} =
 
 import ../ui/utils
 
-# template button*[T](s: State[T] = state(void),
-#                     name: string,
-#                     blk: untyped) =
-#   button(s, name, void, blk)
-
-# template button*(name: string,
-#                  value: untyped,
-#                  blk: untyped) =
-#   button(state(void), name, value, blk)
-
-# template button*(name: string,
-#                  blk: untyped) =
-#   button(state(void), name, void, blk)
-
-from sugar import capture
-import macros
-
-template exportWidget*(name, widget: untyped) =
-  macro `name`*(args: varargs[untyped]) =
-    let widget = ident(repr `widget`)
-    let wargs = args.parseWidgetArgs()
-    result = widget.generateBodies(wargs)
-
-
 exportWidget(button, Button)
-
-# template button*[V](id: string, value: V, blk: untyped) =
-# # template button*(id: string, blk: untyped) =
-#   button[void, V](void, id, value, blk)

--- a/figuro/widgets/button.nim
+++ b/figuro/widgets/button.nim
@@ -1,5 +1,6 @@
 
 import commons
+import ../ui/utils
 
 type
   StatefulWidget*[T] = ref object of Figuro
@@ -31,22 +32,20 @@ proc clicked*[T](self: Button[T],
     refresh(self)
   self.isActive = true
 
-proc draw*[T](self: Button[T]) {.widget, slot.} =
+proc draw*[T](self: Button[T]) {.slot.} =
   ## button widget!
-  # current = self
-  # echo "button:draw"
-  var current = self
-  
-  clipContent true
-  cornerRadius 10.0
+  withDraw(self):
+    
+    clipContent true
+    cornerRadius 10.0
 
-  if self.disabled:
-    fill "#F0F0F0"
-  else:
-    fill "#2B9FEA"
-    onHover:
-      fill current.fill.spin(15)
-      # this changes the color on hover!
+    if self.disabled:
+      fill "#F0F0F0"
+    else:
+      fill "#2B9FEA"
+      onHover:
+        fill current.fill.spin(15)
+        # this changes the color on hover!
 
 import ../ui/utils
 
@@ -64,10 +63,6 @@ template button*[T; V](typ: typedesc[T],
         if postDrawReady in widget.attrs:
           widget.attrs.excl postDrawReady
           `blk`
-    # connect(current, onDraw, current, Button[T].draw())
-    # connect(current, onDraw, current, postDraw)
-    # connect(current, onClick, current, Button[T].clicked)
-    # connect(current, onHover, current, Button[T].hovered)
     postNode(Figuro(current))
 
 # template button*[V](id: string, value: V, blk: untyped) =

--- a/figuro/widgets/button.nim
+++ b/figuro/widgets/button.nim
@@ -66,16 +66,14 @@ import ../ui/utils
 from sugar import capture
 import macros
 
-macro button*(args: varargs[untyped]) =
-  echo "button:\n", args.treeRepr
-  # echo "do:\n", args[2].treeRepr
-  let widget = ident "Button"
-  let wargs = args.parseWidgetArgs()
+template exportWidget*(name, widget: untyped) =
+  macro `name`*(args: varargs[untyped]) =
+    let widget = ident(repr `widget`)
+    let wargs = args.parseWidgetArgs()
+    result = widget.generateBodies(wargs)
 
-  result = widget.generateBodies(wargs)
-  echo "button:result:\n", result.repr
-  
 
+exportWidget(button, Button)
 
 # template button*[V](id: string, value: V, blk: untyped) =
 # # template button*(id: string, blk: untyped) =

--- a/figuro/widgets/button.nim
+++ b/figuro/widgets/button.nim
@@ -70,10 +70,19 @@ template button*[T](s: State[T],
           `blk`
     postNode(Figuro(current))
 
-template button*[T](s: State[T],
+template button*[T](s: State[T] = state(void),
                     name: string,
                     blk: untyped) =
   button(s, name, void, blk)
+
+template button*(name: string,
+                    blk: untyped) =
+  button(state(void), name, void, blk)
+
+template button*(name: string,
+                    value: untyped,
+                    blk: untyped) =
+  button(state(void), name, value, blk)
 
 # import macros
 # macro button*(s, args: varargs[untyped]) =

--- a/figuro/widgets/button.nim
+++ b/figuro/widgets/button.nim
@@ -70,7 +70,7 @@ macro button*(args: varargs[untyped]) =
   # echo "do:\n", args[2].treeRepr
   let id = args[0]
   var stateArg: NimNode
-  var capturedVals: seq[NimNode]
+  var capturedVals: NimNode = nnkBracket.newTree()
   var isCaptured: bool
 
   var blk: NimNode = args[^1]
@@ -84,7 +84,7 @@ macro button*(args: varargs[untyped]) =
         # arg[1].expectKind(nnkBracket)
         stateArg = arg[1]
       elif fname.repr == "captures":
-        capturedVals = arg[1..^1]
+        capturedVals.add arg[1..^1]
 
   let body = quote do:
       current.postDraw = proc (widget: Figuro) =

--- a/figuro/widgets/button.nim
+++ b/figuro/widgets/button.nim
@@ -65,6 +65,7 @@ import ../ui/utils
 
 from sugar import capture
 import macros
+
 macro button*(args: varargs[untyped]) =
   echo "button:\n", args.treeRepr
   # echo "do:\n", args[2].treeRepr

--- a/figuro/widgets/button.nim
+++ b/figuro/widgets/button.nim
@@ -60,17 +60,13 @@ template button*[T; V](typ: typedesc[T],
     preNode(nkRectangle, name, current, parent)
     captureArgs value:
       current.postDraw = proc (widget: Figuro) =
-        # echo nd(), "button:postDraw: ", " name: ", (widget).getName()
-        # echo nd(), "button:postDraw: ", widget.getId, " widget is button: ", widget is Button[T]
         var current {.inject.}: Button[T] = Button[T](widget)
-        # echo "BUTTON: ", current.getId, " parent: ", current.parent.getId
-        # let widget {.inject.} = Button[T](current)
         if postDrawReady in widget.attrs:
           widget.attrs.excl postDrawReady
           `blk`
     # connect(current, onDraw, current, Button[T].draw())
     # connect(current, onDraw, current, postDraw)
-    connect(current, onClick, current, Button[T].clicked)
+    # connect(current, onClick, current, Button[T].clicked)
     # connect(current, onHover, current, Button[T].hovered)
     postNode(Figuro(current))
 

--- a/figuro/widgets/button.nim
+++ b/figuro/widgets/button.nim
@@ -12,15 +12,9 @@ type
     disabled*: bool
 
 proc hover*[T](self: Button[T], kind: EventKind) {.slot.} =
-  # self.fill = parseHtmlColor "#9BDFFA"
-  # echo "button hover!"
   echo "button:hovered: ", kind, " :: ", self.getId,
           " buttons: ", self.events.mouse
-  # if kind == Enter:
-  #   self.events.mouse.incl evHover
-  # else:
-  #   self.events.mouse.excl evHover
-  # refresh(self)
+  
 
 proc clicked*[T](self: Button[T],
                   kind: EventKind,
@@ -46,7 +40,5 @@ proc draw*[T](self: Button[T]) {.slot.} =
       onHover:
         fill current.fill.spin(15)
         # this changes the color on hover!
-
-import ../ui/utils
 
 exportWidget(button, Button)

--- a/figuro/widgets/button.nim
+++ b/figuro/widgets/button.nim
@@ -49,10 +49,15 @@ proc draw*[T](self: Button[T]) {.slot.} =
 
 import ../ui/utils
 
-template button*[T; V](typ: typedesc[T],
-                        name: string,
-                        value: V,
-                        blk: untyped) =
+type
+  State*[T] = object
+
+proc state*[T](tp: typedesc[T]): State[T] = discard
+
+template button*[T](s: State[T],
+                    name: string,
+                    value: untyped,
+                    blk: untyped) =
   block:
     var parent: Figuro = Figuro(current)
     var current {.inject.}: Button[T] = nil
@@ -64,6 +69,16 @@ template button*[T; V](typ: typedesc[T],
           widget.attrs.excl postDrawReady
           `blk`
     postNode(Figuro(current))
+
+template button*[T](s: State[T],
+                    name: string,
+                    blk: untyped) =
+  button(s, name, void, blk)
+
+# import macros
+# macro button*(s, args: varargs[untyped]) =
+#   echo "button: ", s.treeRepr
+
 
 # template button*[V](id: string, value: V, blk: untyped) =
 # # template button*(id: string, blk: untyped) =

--- a/figuro/widgets/button.nim
+++ b/figuro/widgets/button.nim
@@ -51,44 +51,27 @@ import ../ui/utils
 
 type
   State*[T] = object
+  Captures* = object
 
 proc state*[T](tp: typedesc[T]): State[T] = discard
 
-# template buttonWidget*[T](
-#                           name: string,
-#                           blk: untyped) =
-#   block:
-#     var parent: Figuro = Figuro(current)
-#     var current {.inject.}: Button[T] = nil
-#     preNode(nkRectangle, name, current, parent)
-#     captureArgs value:
-#       current.postDraw = proc (widget: Figuro) =
-#         var current {.inject.}: Button[T] = Button[T](widget)
-#         if postDrawReady in widget.attrs:
-#           widget.attrs.excl postDrawReady
-#           `blk`
-#     postNode(Figuro(current))
-
-proc buttonWidget*[T](
+template button*[T; V](
     name: string,
-    current: var Button[T],
-    parent: var Figuro,
-    body: proc (self: Button[T])
+    state: State[T],
+    value: V,
+    blk: untyped
 ) =
-    preNode(nkRectangle, name, current, parent)
-    current.postDraw = proc (widget: Figuro) =
-        var self: Button[T] = Button[T](widget)
-        if postDrawReady in self.attrs:
-          self.attrs.excl postDrawReady
-          body(self)
-    postNode(Figuro(current))
-
-template button*[T](name: string,
-                body: proc (self: Button[T])) =
   block:
-    var parent: Figuro = current
+    var parent: Figuro = Figuro(current)
     var current {.inject.}: Button[T] = nil
-    buttonWidget(name, current, parent, body)
+    preNode(nkRectangle, name, current, parent)
+    captureArgs value:
+      current.postDraw = proc (widget: Figuro) =
+        var current {.inject.}: Button[T] = Button[T](widget)
+        if postDrawReady in widget.attrs:
+          widget.attrs.excl postDrawReady
+          `blk`
+    postNode(Figuro(current))
 
 # template button*[T](s: State[T] = state(void),
 #                     name: string,

--- a/figuro/widgets/button.nim
+++ b/figuro/widgets/button.nim
@@ -49,52 +49,7 @@ proc draw*[T](self: Button[T]) {.slot.} =
 
 import ../ui/utils
 
-type
-  State*[T] = object
-  Captures*[V] = object
-    val*: V
-
-import macros
-
-proc state*[T](tp: typedesc[T]): State[T] = discard
-
-macro captures*(vals: varargs[untyped]): untyped = 
-  echo "captures: ", vals.treeRepr
-  var tpl = nnkTupleConstr.newNimNode()
-  for val in vals:
-    # echo "captures:val: ", val.getTypeInst.repr
-    tpl.add val
-  result = quote do:
-    Captures[typeof(`tpl`)](val: `tpl`)
-  echo "captures:res: ", result.repr
-
-template button*[T; V](
-    name: string,
-    state: State[T],
-    value: Captures[V],
-    blk: untyped
-) =
-  block:
-    var parent: Figuro = Figuro(current)
-    var current {.inject.}: Button[T] = nil
-    preNode(nkRectangle, name, current, parent)
-    captureArgs value:
-      current.postDraw = proc (widget: Figuro) =
-        var current {.inject.}: Button[T] = Button[T](widget)
-        if postDrawReady in widget.attrs:
-          widget.attrs.excl postDrawReady
-          `blk`
-    postNode(Figuro(current))
-
-template button*[V](name: string, value: Captures[V], blk: untyped) =
-  button(name, state(void), value, blk)
-
-template button*[T](name: string, state: State[T], blk: untyped) =
-  button(name, state, captures(), blk)
-
-template button*(name: string, blk: untyped) =
-  button(name, state(void), void, blk)
-
+declareStatefulWidget(button, Button)
 
 # template button*[T](s: State[T] = state(void),
 #                     name: string,

--- a/figuro/widgets/button.nim
+++ b/figuro/widgets/button.nim
@@ -70,8 +70,8 @@ macro captures*(vals: varargs[untyped]): untyped =
 
 template button*[T; V](
     name: string,
-    state: State[T] = state(void),
-    value: V,
+    state: State[T],
+    value: Captures[V],
     blk: untyped
 ) =
   block:
@@ -86,8 +86,11 @@ template button*[T; V](
           `blk`
     postNode(Figuro(current))
 
-template button*[V]( name: string, value: V, blk: untyped) =
+template button*[V](name: string, value: Captures[V], blk: untyped) =
   button(name, state(void), value, blk)
+
+template button*[T](name: string, state: State[T], blk: untyped) =
+  button(name, state, captures(), blk)
 
 template button*(name: string, blk: untyped) =
   button(name, state(void), void, blk)

--- a/figuro/widgets/button.nim
+++ b/figuro/widgets/button.nim
@@ -71,8 +71,7 @@ macro button*(args: varargs[untyped]) =
   # echo "do:\n", args[2].treeRepr
   let id = args[0]
   var stateArg: NimNode
-  var capturedVals: NimNode = nnkBracket.newTree()
-  var isCaptured: bool
+  var capturedVals: NimNode = nil
 
   var blk: NimNode = args[^1]
 
@@ -85,7 +84,7 @@ macro button*(args: varargs[untyped]) =
         # arg[1].expectKind(nnkBracket)
         stateArg = arg[1]
       elif fname.repr == "captures":
-        isCaptured = true
+        capturedVals = nnkBracket.newTree()
         capturedVals.add arg[1..^1]
 
   let body = quote do:
@@ -96,7 +95,7 @@ macro button*(args: varargs[untyped]) =
           `blk`
 
   let outer =
-    if isCaptured:
+    if not capturedVals.isNil:
       quote do:
         capture `capturedVals`:
           `body`

--- a/figuro/widgets/button.nim
+++ b/figuro/widgets/button.nim
@@ -84,6 +84,7 @@ macro button*(args: varargs[untyped]) =
         # arg[1].expectKind(nnkBracket)
         stateArg = arg[1]
       elif fname.repr == "captures":
+        isCaptured = true
         capturedVals.add arg[1..^1]
 
   let body = quote do:
@@ -93,7 +94,7 @@ macro button*(args: varargs[untyped]) =
           widget.attrs.excl postDrawReady
           `blk`
 
-  let outer = 
+  let outer =
     if isCaptured:
       quote do:
         capture `capturedVals`:

--- a/figuro/widgets/button.nim
+++ b/figuro/widgets/button.nim
@@ -54,20 +54,41 @@ type
 
 proc state*[T](tp: typedesc[T]): State[T] = discard
 
-template buttonWidget*[T](
-                          name: string,
-                          blk: untyped) =
-  block:
-    var parent: Figuro = Figuro(current)
-    var current {.inject.}: Button[T] = nil
+# template buttonWidget*[T](
+#                           name: string,
+#                           blk: untyped) =
+#   block:
+#     var parent: Figuro = Figuro(current)
+#     var current {.inject.}: Button[T] = nil
+#     preNode(nkRectangle, name, current, parent)
+#     captureArgs value:
+#       current.postDraw = proc (widget: Figuro) =
+#         var current {.inject.}: Button[T] = Button[T](widget)
+#         if postDrawReady in widget.attrs:
+#           widget.attrs.excl postDrawReady
+#           `blk`
+#     postNode(Figuro(current))
+
+proc buttonWidget*[T](
+    name: string,
+    current: var Button[T],
+    parent: var Figuro,
+    body: proc (self: Button[T])
+) =
     preNode(nkRectangle, name, current, parent)
-    captureArgs value:
-      current.postDraw = proc (widget: Figuro) =
-        var current {.inject.}: Button[T] = Button[T](widget)
-        if postDrawReady in widget.attrs:
-          widget.attrs.excl postDrawReady
-          `blk`
+    current.postDraw = proc (widget: Figuro) =
+        var self: Button[T] = Button[T](widget)
+        if postDrawReady in self.attrs:
+          self.attrs.excl postDrawReady
+          body(self)
     postNode(Figuro(current))
+
+template button*[T](name: string,
+                body: proc (self: Button[T])) =
+  block:
+    var parent: Figuro = current
+    var current {.inject.}: Button[T] = nil
+    buttonWidget(name, current, parent, body)
 
 # template button*[T](s: State[T] = state(void),
 #                     name: string,
@@ -85,62 +106,62 @@ template buttonWidget*[T](
 
 from sugar import capture
 import macros
-macro button*(args: varargs[untyped]) =
-  echo "button:\n", args.treeRepr
-  # echo "do:\n", args[2].treeRepr
-  let id = args[0]
-  var stateArg: NimNode
-  var blk: NimNode
-  var capturedVals: NimNode
-  var isCaptured: bool
+# macro button*(args: varargs[untyped]) =
+#   echo "button:\n", args.treeRepr
+#   # echo "do:\n", args[2].treeRepr
+#   let id = args[0]
+#   var stateArg: NimNode
+#   var blk: NimNode
+#   var capturedVals: NimNode
+#   var isCaptured: bool
 
-  for arg in args:
-    if arg.kind == nnkExprEqExpr and arg[0].repr == "state":
-      arg[1].expectKind(nnkBracket)
-      assert arg[1].len() == 1
-      stateArg = arg[1][0]
+#   for arg in args:
+#     if arg.kind == nnkExprEqExpr and arg[0].repr == "state":
+#       arg[1].expectKind(nnkBracket)
+#       assert arg[1].len() == 1
+#       stateArg = arg[1][0]
 
-  if args[2].kind == nnkDo:
-    let doblk = args[2]
-    let pms = doblk.params()
-    blk = doblk[^1]
-    echo "pms:\n", pms.treeRepr
+#   if args[2].kind == nnkDo:
+#     let doblk = args[2]
+#     let pms = doblk.params()
+#     blk = doblk[^1]
+#     echo "pms:\n", pms.treeRepr
 
-    var vals = nnkBracket.newNimNode()
-    for arg in pms[1..^1]: vals.add arg[0]
-    capturedVals = vals
-    echo "vals: ", vals.repr
-    echo "state: ", stateArg.repr
-    isCaptured = true
-  else:
-    capturedVals = nnkBracket.newTree()
-    blk = args[^1]
+#     var vals = nnkBracket.newNimNode()
+#     for arg in pms[1..^1]: vals.add arg[0]
+#     capturedVals = vals
+#     echo "vals: ", vals.repr
+#     echo "state: ", stateArg.repr
+#     isCaptured = true
+#   else:
+#     capturedVals = nnkBracket.newTree()
+#     blk = args[^1]
 
-  let body = quote do:
-      current.postDraw = proc (widget: Figuro) =
-        var current {.inject.}: Button[`stateArg`] = Button[`stateArg`](widget)
-        if postDrawReady in widget.attrs:
-          widget.attrs.excl postDrawReady
-          `blk`
+#   let body = quote do:
+#       current.postDraw = proc (widget: Figuro) =
+#         var current {.inject.}: Button[`stateArg`] = Button[`stateArg`](widget)
+#         if postDrawReady in widget.attrs:
+#           widget.attrs.excl postDrawReady
+#           `blk`
 
-  let outer = 
-    if isCaptured:
-      quote do:
-        capture `capturedVals`:
-          `body`
-    else:
-      quote do:
-        `body`
+#   let outer = 
+#     if isCaptured:
+#       quote do:
+#         capture `capturedVals`:
+#           `body`
+#     else:
+#       quote do:
+#         `body`
 
-  result = quote do:
-    block:
-      var parent: Figuro = Figuro(current)
-      var current {.inject.}: Button[`stateArg`] = nil
-      preNode(nkRectangle, `id`, current, parent)
-      `outer`
-      postNode(Figuro(current))
+#   result = quote do:
+#     block:
+#       var parent: Figuro = Figuro(current)
+#       var current {.inject.}: Button[`stateArg`] = nil
+#       preNode(nkRectangle, `id`, current, parent)
+#       `outer`
+#       postNode(Figuro(current))
 
-  echo "button:result:\n", result.repr
+#   echo "button:result:\n", result.repr
   
 
 

--- a/figuro/widgets/button.nim
+++ b/figuro/widgets/button.nim
@@ -69,10 +69,10 @@ import macros
 macro button*(args: varargs[untyped]) =
   echo "button:\n", args.treeRepr
   # echo "do:\n", args[2].treeRepr
+  let widget = ident "Button"
   let id = args[0]
   var stateArg: NimNode
   var capturedVals: NimNode = nil
-
   var blk: NimNode = args[^1]
 
   for arg in args[0..^2]:
@@ -89,7 +89,7 @@ macro button*(args: varargs[untyped]) =
 
   let body = quote do:
       current.postDraw = proc (widget: Figuro) =
-        var current {.inject.}: Button[`stateArg`] = Button[`stateArg`](widget)
+        var current {.inject.}: `widget`[`stateArg`] = `widget`[`stateArg`](widget)
         if postDrawReady in widget.attrs:
           widget.attrs.excl postDrawReady
           `blk`
@@ -106,7 +106,7 @@ macro button*(args: varargs[untyped]) =
   result = quote do:
     block:
       var parent: Figuro = Figuro(current)
-      var current {.inject.}: Button[`stateArg`] = nil
+      var current {.inject.}: `widget`[`stateArg`] = nil
       preNode(nkRectangle, `id`, current, parent)
       `outer`
       postNode(Figuro(current))

--- a/tests/tclick.nim
+++ b/tests/tclick.nim
@@ -72,7 +72,7 @@ proc draw*(self: Main) {.slot.} =
                       spin(10*self.hoveredAlpha)
       let x = 10
       for i in 0 .. 4:
-        button "btn":
+        button state(int), "btn", (i):
           box 10 + 120, 10, 100, 100
 
           # connect(current, onHover, self, Main.hover)

--- a/tests/tclick.nim
+++ b/tests/tclick.nim
@@ -96,5 +96,4 @@ connect(main, onTick, main, Main.tick())
 
 app.width = 720
 app.height = 140
-
 startFiguro(main)

--- a/tests/tclick.nim
+++ b/tests/tclick.nim
@@ -68,7 +68,8 @@ proc draw*(self: Main) {.slot.} =
       self.mainRect = current
       box 10, 10, 600, 120
       cornerRadius 10.0
-      fill whiteColor.darken(self.hoveredAlpha).spin(10*self.hoveredAlpha)
+      fill whiteColor.darken(self.hoveredAlpha).
+                      spin(10*self.hoveredAlpha)
       for i in 0 .. 4:
         button int, "btn" & $i, i:
           box 10 + i * 120, 10, 100, 100

--- a/tests/tclick.nim
+++ b/tests/tclick.nim
@@ -74,21 +74,21 @@ proc draw*(self: Main) {.slot.} =
                       spin(10*self.hoveredAlpha)
       let x = 10
       for i in 0 .. 4:
-        button "btn", state(int), captures(i):
+        button "btn", state(Counter), captures(i):
           box 10 + i*120, 10, 100, 100
 
-          connect(current, onHover, self, Main.hover)
-          connect(current, onClick, current, btnClicked)
-          if i == 0:
-            connect(self, update, current, btnTick)
+          # connect(current, onHover, self, Main.hover)
+          # connect(current, onClick, current, btnClicked)
+          # if i == 0:
+          #   connect(self, update, current, btnTick)
 
-          node nkText, "text":
-            box 10, 10, 70, 70
-            fill blackColor
-            setText(font, $(Button[int](current.parent).state))
-            connect(current, onClick, current, Figuro.txtClicked())
-            bubble(onClick)
-            connect(current, onHover, current, Figuro.txtHovered())
+          # node nkText, "text":
+          #   box 10, 10, 70, 70
+          #   fill blackColor
+          #   setText(font, $(Button[int](current.parent).state))
+          #   connect(current, onClick, current, Figuro.txtClicked())
+          #   bubble(onClick)
+          #   connect(current, onHover, current, Figuro.txtHovered())
 
 var main = Main.new()
 connect(main, onDraw, main, Main.draw())

--- a/tests/tclick.nim
+++ b/tests/tclick.nim
@@ -84,14 +84,12 @@ proc draw*(self: Main) {.slot.} =
             connect(self, update, current, Button[int].btnTick())
 
           node nkText, "text":
-            # echo nd(), "text: ", current.getId, " parent: ", current.parent.getId
             box 10, 10, 70, 70
             fill blackColor
             setText(font, $(Button[int](current.parent).state))
             connect(current, onClick, current, Figuro.txtClicked())
             bubble(onClick)
             connect(current, onHover, current, Figuro.txtHovered())
-            # bubble(onHover)
 
 var main = Main.new()
 

--- a/tests/tclick.nim
+++ b/tests/tclick.nim
@@ -70,22 +70,23 @@ proc draw*(self: Main) {.slot.} =
       cornerRadius 10.0
       fill whiteColor.darken(self.hoveredAlpha).
                       spin(10*self.hoveredAlpha)
+      let x = 10
       for i in 0 .. 4:
-        button int, "btn" & $i, i:
-          box 10 + i * 120, 10, 100, 100
+        button state(int), "btn", (i, x):
+          box 10 + 120, 10, 100, 100
 
-          connect(current, onHover, self, Main.hover)
-          connect(current, onClick, current, Button[int].btnClicked())
-          if i == 0:
-            connect(self, update, current, Button[int].btnTick())
+          # connect(current, onHover, self, Main.hover)
+          # connect(current, onClick, current, Button[int].btnClicked())
+          # if i == 0:
+          #   connect(self, update, current, Button[int].btnTick())
 
-          node nkText, "text":
-            box 10, 10, 70, 70
-            fill blackColor
-            setText(font, $(Button[int](current.parent).state))
-            connect(current, onClick, current, Figuro.txtClicked())
-            bubble(onClick)
-            connect(current, onHover, current, Figuro.txtHovered())
+          # node nkText, "text":
+          #   box 10, 10, 70, 70
+          #   fill blackColor
+          #   setText(font, $(Button[int](current.parent).state))
+          #   connect(current, onClick, current, Figuro.txtClicked())
+          #   bubble(onClick)
+          #   connect(current, onHover, current, Figuro.txtHovered())
 
 var main = Main.new()
 connect(main, onDraw, main, Main.draw())

--- a/tests/tclick.nim
+++ b/tests/tclick.nim
@@ -87,11 +87,8 @@ proc draw*(self: Main) {.slot.} =
             connect(current, onHover, current, Figuro.txtHovered())
 
 var main = Main.new()
-
 connect(main, onDraw, main, Main.draw())
 connect(main, onTick, main, Main.tick())
-
-echo "main: ", main.listeners
 
 app.width = 720
 app.height = 140

--- a/tests/tclick.nim
+++ b/tests/tclick.nim
@@ -1,15 +1,10 @@
-
-## This minimal example shows 5 blue squares.
 import figuro/widgets/button
 import figuro/widget
 import figuro
 
 let
   typeface = loadTypeFace("IBMPlexSans-Regular.ttf")
-  font = loadFont: GlyphFont(
-      typefaceId: typeface,
-      size: 44
-    )
+  font = loadFont: GlyphFont(typefaceId: typeface, size: 44)
 
 type
   Main* = ref object of Figuro

--- a/tests/tclick.nim
+++ b/tests/tclick.nim
@@ -74,21 +74,21 @@ proc draw*(self: Main) {.slot.} =
                       spin(10*self.hoveredAlpha)
       let x = 10
       for i in 0 .. 4:
-        button "btn", state(Counter), captures(i):
+        button "btn", state(int), captures(i):
           box 10 + i*120, 10, 100, 100
 
-          # connect(current, onHover, self, Main.hover)
-          # connect(current, onClick, current, btnClicked)
-          # if i == 0:
-          #   connect(self, update, current, btnTick)
+          connect(current, onHover, self, Main.hover)
+          connect(current, onClick, current, btnClicked)
+          if i == 0:
+            connect(self, update, current, btnTick)
 
-          # node nkText, "text":
-          #   box 10, 10, 70, 70
-          #   fill blackColor
-          #   setText(font, $(Button[int](current.parent).state))
-          #   connect(current, onClick, current, Figuro.txtClicked())
-          #   bubble(onClick)
-          #   connect(current, onHover, current, Figuro.txtHovered())
+          node nkText, "text":
+            box 10, 10, 70, 70
+            fill blackColor
+            setText(font, $(Button[int](current.parent).state))
+            connect(current, onClick, current, Figuro.txtClicked())
+            bubble(onClick)
+            connect(current, onHover, current, Figuro.txtHovered())
 
 var main = Main.new()
 connect(main, onDraw, main, Main.draw())

--- a/tests/tclick.nim
+++ b/tests/tclick.nim
@@ -7,6 +7,8 @@ let
   font = loadFont: GlyphFont(typefaceId: typeface, size: 44)
 
 type
+  Counter* = object
+
   Main* = ref object of Figuro
     value: int
     hasHovered: bool
@@ -72,8 +74,8 @@ proc draw*(self: Main) {.slot.} =
                       spin(10*self.hoveredAlpha)
       let x = 10
       for i in 0 .. 4:
-        button state(int), "btn", (i):
-          box 10 + 120, 10, 100, 100
+        button "btn", state=[Counter] do(i):
+          box 10 + i*120, 10, 100, 100
 
           # connect(current, onHover, self, Main.hover)
           # connect(current, onClick, current, Button[int].btnClicked())

--- a/tests/tclick.nim
+++ b/tests/tclick.nim
@@ -74,21 +74,21 @@ proc draw*(self: Main) {.slot.} =
                       spin(10*self.hoveredAlpha)
       let x = 10
       for i in 0 .. 4:
-        button "btn", captures(i):
+        button "btn", state(int), captures(i):
           box 10 + i*120, 10, 100, 100
 
-          # connect(current, onHover, self, Main.hover)
-          # connect(current, onClick, current, Button[int].btnClicked())
-          # if i == 0:
-          #   connect(self, update, current, Button[int].btnTick())
+          connect(current, onHover, self, Main.hover)
+          connect(current, onClick, current, btnClicked)
+          if i == 0:
+            connect(self, update, current, btnTick)
 
-          # node nkText, "text":
-          #   box 10, 10, 70, 70
-          #   fill blackColor
-          #   setText(font, $(Button[int](current.parent).state))
-          #   connect(current, onClick, current, Figuro.txtClicked())
-          #   bubble(onClick)
-          #   connect(current, onHover, current, Figuro.txtHovered())
+          node nkText, "text":
+            box 10, 10, 70, 70
+            fill blackColor
+            setText(font, $(Button[int](current.parent).state))
+            connect(current, onClick, current, Figuro.txtClicked())
+            bubble(onClick)
+            connect(current, onHover, current, Figuro.txtHovered())
 
 var main = Main.new()
 connect(main, onDraw, main, Main.draw())

--- a/tests/tclick.nim
+++ b/tests/tclick.nim
@@ -72,7 +72,7 @@ proc draw*(self: Main) {.slot.} =
                       spin(10*self.hoveredAlpha)
       let x = 10
       for i in 0 .. 4:
-        button state(int), "btn", (i, x):
+        button "btn":
           box 10 + 120, 10, 100, 100
 
           # connect(current, onHover, self, Main.hover)

--- a/tests/tclick.nim
+++ b/tests/tclick.nim
@@ -60,17 +60,17 @@ proc hover*(self: Main, kind: EventKind) {.slot.} =
   refresh(self)
 
 proc draw*(self: Main) {.slot.} =
-  var current = self
-  self.name.setLen(0)
-  self.name.add "main"
+  withDraw(self):
+    self.name.setLen(0)
+    self.name.add "main"
 
-  rectangle "body":
-    self.mainRect = current
-    box 10, 10, 600, 120
-    cornerRadius 10.0
-    fill whiteColor.darken(self.hoveredAlpha).spin(10*self.hoveredAlpha)
-    for i in 0 .. 4:
-      button int, "btn" & $i, i:
+    rectangle "body":
+      self.mainRect = current
+      box 10, 10, 600, 120
+      cornerRadius 10.0
+      fill whiteColor.darken(self.hoveredAlpha).spin(10*self.hoveredAlpha)
+      for i in 0 .. 4:
+        button int, "btn" & $i, i:
           box 10 + i * 120, 10, 100, 100
 
           connect(current, onHover, self, Main.hover)

--- a/tests/tclick.nim
+++ b/tests/tclick.nim
@@ -74,7 +74,7 @@ proc draw*(self: Main) {.slot.} =
                       spin(10*self.hoveredAlpha)
       let x = 10
       for i in 0 .. 4:
-        button "btn", state(int), (i):
+        button "btn", captures(i):
           box 10 + i*120, 10, 100, 100
 
           # connect(current, onHover, self, Main.hover)

--- a/tests/tclick.nim
+++ b/tests/tclick.nim
@@ -74,7 +74,7 @@ proc draw*(self: Main) {.slot.} =
                       spin(10*self.hoveredAlpha)
       let x = 10
       for i in 0 .. 4:
-        button("btn") do (self: Button[int]):
+        button "btn", state(int), (i):
           box 10 + i*120, 10, 100, 100
 
           # connect(current, onHover, self, Main.hover)

--- a/tests/tclick.nim
+++ b/tests/tclick.nim
@@ -68,7 +68,6 @@ proc draw*(self: Main) {.slot.} =
   var current = self
   self.name.setLen(0)
   self.name.add "main"
-  # echo "\n\nmain:draw: ", current.getId, " parent: ", current.parent.getId
 
   rectangle "body":
     self.mainRect = current
@@ -76,21 +75,14 @@ proc draw*(self: Main) {.slot.} =
     cornerRadius 10.0
     fill whiteColor.darken(self.hoveredAlpha).spin(10*self.hoveredAlpha)
     for i in 0 .. 4:
-      # button "btn", i, typ = void:
       button int, "btn" & $i, i:
           box 10 + i * 120, 10, 100, 100
 
           connect(current, onHover, self, Main.hover)
-          # connect(current, onHover, current, Button[int].hover)
-          # echo nd(), "button:draw: ", " :: ", current.getId, " name: ", current.name
           connect(current, onClick, current, Button[int].btnClicked())
           if i == 0:
             connect(self, update, current, Button[int].btnTick())
-          # connect(current, onDraw, current, draw)
 
-          # The challenges of developing UIs!
-          # button int, "btn", i:
-          #   box 10, 10, 20, 20
           node nkText, "text":
             # echo nd(), "text: ", current.getId, " parent: ", current.parent.getId
             box 10, 10, 70, 70

--- a/tests/tclick.nim
+++ b/tests/tclick.nim
@@ -74,7 +74,7 @@ proc draw*(self: Main) {.slot.} =
                       spin(10*self.hoveredAlpha)
       let x = 10
       for i in 0 .. 4:
-        button "btn", state=[Counter] do(i):
+        button("btn") do (self: Button[int]):
           box 10 + i*120, 10, 100, 100
 
           # connect(current, onHover, self, Main.hover)


### PR DESCRIPTION
Hmmmm, tried a bit of everything:
- pure procs with do bodies
- pure templates
- macros
- macros & templates

The simplest solution (for now) appears to be a template which exports a macro for each widget. While this will slow compilation down, it's only one per widget. 

It'd be possible to rework this to have a macro / compile process which spits out templates that work the same but with type overloads for all the default cases.

