### PR TITLE
Fixing fonts

### DIFF
--- a/figuro/renderer/opengl/fontutils.nim
+++ b/figuro/renderer/opengl/fontutils.nim
@@ -59,8 +59,11 @@ iterator glyphs*(arrangement: GlyphArrangement): GlyphPosition =
       # echo "span: ", span.repr
       # let
       #   span = span[0] ..< span[1]
+      echo "GLYPHS: zip", " i: ", i, " span: ", span, " gfont: ", gfont.fontId
 
       while idx < arrangement.runes.len():
+        echo "GLYPHS: ", " idx: ", idx
+
         let
           pos = arrangement.positions[idx]
           rune = arrangement.runes[idx]
@@ -75,11 +78,10 @@ iterator glyphs*(arrangement: GlyphArrangement): GlyphPosition =
           descent: gfont.lineHeight,
         )
 
+        echo "GLYPHS: ", " idx in span: ", idx in span
+        idx.inc()
         if idx notin span:
-          idx.inc()
           break
-        else:
-          idx.inc()
 
 var
   typefaceTable*: Table[TypefaceId, Typeface]

--- a/figuro/renderer/opengl/fontutils.nim
+++ b/figuro/renderer/opengl/fontutils.nim
@@ -194,7 +194,7 @@ proc getTypeset*(
     wh = box.scaled().wh
     sz = uiSpans.mapIt(it[0].size.float)
     minSz = sz.foldl(max(a,b), 0.0)
-  
+
   wh.y = wh.y + minSz * 0.9 # why this?
 
   var spans: seq[Span]
@@ -242,7 +242,7 @@ proc getTypeset*(
   result = GlyphArrangement(
     lines: lines, # arrangement.lines.toSlices(),
     spans: spanSlices, # arrangement.spans.toSlices(),
-    fonts: gfonts, ## FIXME
+    fonts: gfonts,
     runes: arrangement.runes,
     positions: arrangement.positions,
     selectionRects: selectionRects,

--- a/figuro/renderer/opengl/fontutils.nim
+++ b/figuro/renderer/opengl/fontutils.nim
@@ -74,7 +74,7 @@ iterator glyphs*(arrangement: GlyphArrangement): GlyphPosition =
           pos: pos,
           rect: selection,
           descent: gfont.lineHeight + (mlh - gfont.lineHeight)/4, ##\
-            ## adjust the line height for varying sized fonts based 
+            ## adjust the line height for varying sized fonts based
             ## off the max line height and the current font's lh
             ## the 1/4 is empirical, but sorta makes sense
         )

--- a/figuro/renderer/opengl/fontutils.nim
+++ b/figuro/renderer/opengl/fontutils.nim
@@ -73,7 +73,10 @@ iterator glyphs*(arrangement: GlyphArrangement): GlyphPosition =
           rune: rune,
           pos: pos,
           rect: selection,
-          descent: gfont.lineHeight + (mlh - gfont.lineHeight)/4,
+          descent: gfont.lineHeight + (mlh - gfont.lineHeight)/4, ##\
+            ## adjust the line height for varying sized fonts based 
+            ## off the max line height and the current font's lh
+            ## the 1/4 is empirical, but sorta makes sense
         )
 
         # echo "GLYPH: ", rune, " pos: ", pos, " sel: ", selection, " lh: ", gfont.lineHeight, " mlh: ", flh, " : ", flh - gfont.lineHeight

--- a/figuro/renderer/opengl/fontutils.nim
+++ b/figuro/renderer/opengl/fontutils.nim
@@ -55,9 +55,9 @@ iterator glyphs*(arrangement: GlyphArrangement): GlyphPosition =
   var idx = 0
   # if arrangement != nil:
 
-  var flh = 0.0
+  var mlh = 0.0 # maximum line height per row (though this does in total?)
   for f in arrangement.fonts:
-    flh = max(f.lineHeight, flh)
+    mlh = max(f.lineHeight, mlh)
 
   block:
     for i, (span, gfont) in zip(arrangement.spans, arrangement.fonts):
@@ -73,7 +73,7 @@ iterator glyphs*(arrangement: GlyphArrangement): GlyphPosition =
           rune: rune,
           pos: pos,
           rect: selection,
-          descent: gfont.lineHeight + (flh - gfont.lineHeight)/4,
+          descent: gfont.lineHeight + (mlh - gfont.lineHeight)/4,
         )
 
         # echo "GLYPH: ", rune, " pos: ", pos, " sel: ", selection, " lh: ", gfont.lineHeight, " mlh: ", flh, " : ", flh - gfont.lineHeight

--- a/figuro/renderer/opengl/fontutils.nim
+++ b/figuro/renderer/opengl/fontutils.nim
@@ -56,14 +56,7 @@ iterator glyphs*(arrangement: GlyphArrangement): GlyphPosition =
   # if arrangement != nil:
   block:
     for i, (span, gfont) in zip(arrangement.spans, arrangement.fonts):
-      # echo "span: ", span.repr
-      # let
-      #   span = span[0] ..< span[1]
-      echo "GLYPHS: zip", " i: ", i, " span: ", span, " gfont: ", gfont.fontId
-
       while idx < arrangement.runes.len():
-        echo "GLYPHS: ", " idx: ", idx
-
         let
           pos = arrangement.positions[idx]
           rune = arrangement.runes[idx]
@@ -78,7 +71,6 @@ iterator glyphs*(arrangement: GlyphArrangement): GlyphPosition =
           descent: gfont.lineHeight,
         )
 
-        echo "GLYPHS: ", " idx in span: ", idx in span
         idx.inc()
         if idx notin span:
           break

--- a/tests/tfontutils.nim
+++ b/tests/tfontutils.nim
@@ -35,3 +35,5 @@ suite "fontutils":
     check glyphs[1].fontId == fontId 
     check glyphs[2].fontId == smallFontId 
     check glyphs[3].fontId == smallFontId 
+    check glyphs[4].fontId == fontId 
+    check glyphs[5].fontId == fontId 

--- a/tests/tfontutils.nim
+++ b/tests/tfontutils.nim
@@ -1,0 +1,37 @@
+
+import unittest
+import figuro
+import figuro/renderer/opengl/fontutils
+
+let
+  typeface = loadTypeFace("IBMPlexSans-Regular.ttf")
+  font = UiFont(typefaceId: typeface, size: 22'ui)
+  smallFont = UiFont(typefaceId: typeface, size: 12'ui)
+
+import pretty
+
+suite "fontutils":
+
+  test "basic":
+    let box = initBox(10, 10, 400, 100)
+    let spans = {font: "hi",
+                  smallFont: "AA",
+                  font: "AA"}
+    let textLayout = internal.getTypeset(box, spans, 
+              hAlign = FontHorizontal.Left,
+              vAlign = FontVertical.Top)
+
+    print textLayout
+
+    let
+      fontId = textLayout.fonts[0].fontId
+      smallFontId = textLayout.fonts[1].fontId
+      glyphs = textLayout.glyphs().toSeq()
+
+    for glyph in glyphs:
+      print glyph
+
+    check glyphs[0].fontId == fontId 
+    check glyphs[1].fontId == fontId 
+    check glyphs[2].fontId == smallFontId 
+    check glyphs[3].fontId == smallFontId 

--- a/tests/ttext.nim
+++ b/tests/ttext.nim
@@ -6,8 +6,8 @@ import figuro
 
 let
   typeface = loadTypeFace("IBMPlexSans-Regular.ttf")
-  font = UiFont(typefaceId: typeface, size: 22'ui)
-  smallFont = UiFont(typefaceId: typeface, size: 12'ui)
+  font = UiFont(typefaceId: typeface, size: 20'ui)
+  smallFont = UiFont(typefaceId: typeface, size: 13'ui)
 
 type
   Main* = ref object of Figuro
@@ -31,8 +31,18 @@ proc draw*(self: Main) {.slot.} =
       with node:
         box 10'ux, 10'ux, 400'ux, 100'ux
         fill blackColor
-        # setText({font: "hello world!",
-        #           smallFont: "It's a small world"}, vAlign=Top)
+        setText({font: "hello world!",
+                  smallFont: "It's a small world"}, vAlign=Top)
+    text "text":
+      with node:
+        box 10'ux, 10'ux, 400'ux, 100'ux
+        fill blackColor
+        setText({font: "hello world!",
+                  smallFont: "It's a small world"}, vAlign=Middle)
+    text "text":
+      with node:
+        box 10'ux, 10'ux, 400'ux, 100'ux
+        fill blackColor
         setText({font: "hello world!",
                   smallFont: "It's a small world"}, vAlign=Bottom)
     rectangle "main":

--- a/tests/ttext.nim
+++ b/tests/ttext.nim
@@ -36,9 +36,9 @@ proc draw*(self: Main) {.slot.} =
         setText({font: "hello world!",
                   smallFont: "AA's a small world",
                   font: "AA's a big world"})
-      let tl = node.textLayout
-      print tl
-      raise newException(Exception, "done")
+      # let tl = node.textLayout
+      # print tl
+      # raise newException(Exception, "done")
     rectangle "main":
       with node:
         box 10'ux, 10'ux, 400'ux, 100'ux

--- a/tests/ttext.nim
+++ b/tests/ttext.nim
@@ -18,6 +18,8 @@ proc hover*(self: Main, kind: EventKind) {.slot.} =
   self.hasHovered = kind == Enter
   refresh(self)
 
+import pretty
+
 proc draw*(self: Main) {.slot.} =
   var node = self
   rectangle "main":
@@ -29,8 +31,14 @@ proc draw*(self: Main) {.slot.} =
       with node:
         box 10'ux, 10'ux, 400'ux, 100'ux
         fill blackColor
-        setText({font: "hello world!\n",
-                  smallFont: "it's a small world"})
+        # setText({font: "hello world!",
+        #           smallFont: "it's a small world"})
+        setText({font: "hello world!",
+                  smallFont: "AA's a small world",
+                  font: "AA's a big world"})
+      let tl = node.textLayout
+      print tl
+      raise newException(Exception, "done")
     rectangle "main":
       with node:
         box 10'ux, 10'ux, 400'ux, 100'ux

--- a/tests/ttext.nim
+++ b/tests/ttext.nim
@@ -26,7 +26,7 @@ proc draw*(self: Main) {.slot.} =
     with node:
       box 10'ux, 10'ux, 600'ux, 120'ux
       cornerRadius 10.0
-      fill "#2A9EEA".parseHtmlColor * 0.7
+      fill css"#2A9EEA" * 0.7
     text "text":
       with node:
         box 10'ux, 10'ux, 400'ux, 100'ux

--- a/tests/ttext.nim
+++ b/tests/ttext.nim
@@ -32,13 +32,9 @@ proc draw*(self: Main) {.slot.} =
         box 10'ux, 10'ux, 400'ux, 100'ux
         fill blackColor
         # setText({font: "hello world!",
-        #           smallFont: "it's a small world"})
+        #           smallFont: "It's a small world"}, vAlign=Top)
         setText({font: "hello world!",
-                  smallFont: "AA's a small world",
-                  font: "AA's a big world"})
-      # let tl = node.textLayout
-      # print tl
-      # raise newException(Exception, "done")
+                  smallFont: "It's a small world"}, vAlign=Bottom)
     rectangle "main":
       with node:
         box 10'ux, 10'ux, 400'ux, 100'ux


### PR DESCRIPTION
The font alignment is tricky. Pixie and Figuro use different starting corners for placing fonts. 

So Figuro needs to adjust Pixie's layout to one that works with Figuro. It seems the magic formula is `descent: gfont.lineHeight + (mlh - gfont.lineHeight)/4`. This appears to handle smaller fonts on the same line as bigger fonts.