### PR TITLE
Replace macro DSL with just templates

### DIFF
--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -17,8 +17,6 @@ jobs:
           - windows-latest
     steps:
     - uses: actions/checkout@v1
-      with:
-        path: "figuro/"
     - uses: iffy/install-nim@v4
       with:
         version: ${{ matrix.nimversion }}
@@ -29,12 +27,6 @@ jobs:
         nimble install nimble
         nim -v
         nimble -v
-
-    - name: Cache packages
-      uses: actions/cache@v3
-      with:
-        path: vendor
-        key: ${{ runner.os }}-${{ hashFiles('figuro/atlas.lock') }}
 
     - name: Install Deps
       run: |

--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -17,11 +17,19 @@ jobs:
           - windows-latest
     steps:
     - uses: actions/checkout@v1
+
     - uses: iffy/install-nim@v4
       with:
         version: ${{ matrix.nimversion }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Cache packages
+      uses: actions/cache@v3
+      with:
+        path: ~/.nimble
+        key: ${{ runner.os }}-${{ hashFiles('figuro.nimble') }}
+
     - name: Install Nimble
       run: |
         nimble install nimble
@@ -32,12 +40,6 @@ jobs:
       run: |
         # sync deps
         nimble install -d --verbose
-
-    - name: Cache packages
-      uses: actions/cache@v3
-      with:
-        path: ~/.nimble
-        key: ${{ runner.os }}-${{ hashFiles('figuro.nimble') }}
 
     - name: Build Tests
       run: |

--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -33,6 +33,12 @@ jobs:
         # sync deps
         nimble install -d --verbose
 
+    - name: Cache packages
+      uses: actions/cache@v3
+      with:
+        path: ~/.nimble
+        key: ${{ runner.os }}-${{ hashFiles('figuro.nimble') }}
+
     - name: Build Tests
       run: |
         nim test

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -38,10 +38,6 @@ jobs:
         # new atlas workspace
         nimble install -d --verbose
 
-    - name: Test build From fig_ws/
-      run: |
-        ls -lh
-
     - name: Build Tests
       run: |
         cd figuro/

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
       with:
-        path: "fig_ws/"
+        path: "figuro/"
     - uses: iffy/install-nim@v4
       with:
         version: ${{ matrix.nimversion }}

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -14,11 +14,18 @@ jobs:
           - ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+
     - uses: iffy/install-nim@v4
       with:
         version: ${{ matrix.nimversion }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Cache packages
+      uses: actions/cache@v3
+      with:
+        path: ~/.nimble
+        key: ${{ runner.os }}-${{ hashFiles('figuro.nimble') }}
 
     - name: Install Nimble
       run: |
@@ -30,12 +37,6 @@ jobs:
       run: |
         # new atlas workspace
         nimble install -d --verbose
-
-    - name: Cache packages
-      uses: actions/cache@v3
-      with:
-        path: ~/.nimble
-        key: ${{ runner.os }}-${{ hashFiles('figuro.nimble') }}
 
     - name: Test build From fig_ws/
       run: |

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -14,8 +14,6 @@ jobs:
           - ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-      with:
-        path: "figuro/"
     - uses: iffy/install-nim@v4
       with:
         version: ${{ matrix.nimversion }}
@@ -32,6 +30,12 @@ jobs:
       run: |
         # new atlas workspace
         nimble install -d --verbose
+
+    - name: Cache packages
+      uses: actions/cache@v3
+      with:
+        path: ~/.nimble
+        key: ${{ runner.os }}-${{ hashFiles('figuro.nimble') }}
 
     - name: Test build From fig_ws/
       run: |

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: Test build From fig_ws/
       run: |
-        nim c figuro/tests/tclick.nim
+        ls -lh
 
     - name: Build Tests
       run: |

--- a/README.md
+++ b/README.md
@@ -157,11 +157,11 @@ It's possible to manually create nodes, but it's not encouraged. Although it can
 proc draw*(self: Main) {.slot.} =
   var node = self
   block: # rectangle
-    let parent {.inject.}: Figuro = node
-    var node {.inject.}: `widgetType` = nil
+    let parent: Figuro = node
+    var node: BasicFiguro = nil
     preNode(BasicFiguro, "body", node, parent)
     node.preDraw = proc (c: Figuro) =
-      let node {.inject.} = `widgetType`(c)
+      let node {.inject.} = BasicFiguro(c)
       ...
       # sets the bounding box of this node
       box node, 10'ux, 10'ux, 600'ux, 120'ux

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ A GUI toolkit for Nim that is event driven while being small and fast. It tries 
 Example drawing buttons with a fading background when any of them are hovered (see below for how it works):
 
 ```nim
+import figuro/widgets/button
+import figuro/widgets/horizontal
+import figuro/widget
+import figuro/ui/animations
+import figuro
+
 let
   typeface = loadTypeFace("IBMPlexSans-Regular.ttf")
   font = UiFont(typefaceId: typeface, size: 22)
@@ -20,6 +26,7 @@ type
                              incr: 0.010, decr: 0.005)
 
 proc update*(fig: Main) {.signal.}
+
 
 proc btnTick*(self: Button[int]) {.slot.} =
   ## slot to increment a button on every tick 
@@ -34,7 +41,7 @@ proc btnClicked*(self: Button[int],
   ## which we can use to check if it's a mouse click
   if buttons == {MouseLeft} or buttons == {DoubleClick}:
     if kind == Enter:
-      self.state.inc()
+      self.state.inc
       refresh(self)
 
 proc btnHover*(self: Main, evtKind: EventKind) {.slot.} =
@@ -45,13 +52,12 @@ proc btnHover*(self: Main, evtKind: EventKind) {.slot.} =
 proc draw*(self: Main) {.slot.} =
   ## draw slot for Main widget called whenever an event
   ## triggers a node or it's parents to be refreshed
+  var node = self
+  node.setName "main"
 
-  self.setName "main"
-
-  # Calls the widget template `rectangle` which creates a new basic widget node.
-  # Generally used to draw generic boxes.
-  # Here we need to pass the `parent` argument since there's no current `node` set
-  rectangle "body", parent=self:
+  # Calls the widget template `rectangle`.
+  # This creates a new basic widget node. Generally used to draw generic rectangles.
+  rectangle "body":
     with node:
       # sets the bounding box of this node
       box 10'ux, 10'ux, 600'ux, 120'ux
@@ -60,7 +66,7 @@ proc draw*(self: Main) {.slot.} =
       fill whiteColor.darken(self.bkgFade.amount)
 
     # sets up horizontal widget node with alternate syntax
-    horizontal "horiz":
+    Horizontal.new "horiz":
       with node:
         box 10'ux, 0'ux, 100'pp, 100'pp
         # `itemWidth` is needed to set the width of items
@@ -69,11 +75,11 @@ proc draw*(self: Main) {.slot.} =
         layoutItems justify=CxCenter, align=CxCenter
 
       for i in 0 .. 4:
-        buttonOf[int] "btn", captures=[i]:
-          # widgets with generic type like Button can use `<name>Of[T]` to set the generic type, otherwise void is used
+        Button[int].new("btn", captures=i):
           let btn = node
           with node:
             size 100'ux, 100'ux
+            cornerRadius 5.0
             connect(doHover, self, btnHover)
             connect(doClick, node, btnClicked)
           if i == 0:
@@ -84,13 +90,13 @@ proc draw*(self: Main) {.slot.} =
               fill blackColor
               setText({font: $(btn.state)}, Center, Middle)
 
+
 proc tick*(self: Main, tick: int, time: MonoTime) {.slot.} =
-  ## handles background "fade" when buttons are hovered
   self.bkgFade.tick(self)
   emit self.update()
 
 var main = Main.new()
-let frame = newAppFrame(main, size=(400'ui, 140'ui))
+let frame = newAppFrame(main, size=(700'ui, 200'ui))
 startFiguro(frame)
 ```
 

--- a/figuro.nimble
+++ b/figuro.nimble
@@ -6,7 +6,7 @@ srcDir        = "."
 
 # Dependencies
 
-requires "nim >= 2.0.12"
+# requires "nim >= 2.0.12"
 requires "pixie >= 5.0.1"
 requires "cssgrid >= 0.6.1"
 requires "chroma >= 0.2.7"

--- a/figuro.nimble
+++ b/figuro.nimble
@@ -6,7 +6,7 @@ srcDir        = "."
 
 # Dependencies
 
-requires "nim >= 1.6.5"
+requires "nim >= 2.0.12"
 requires "pixie >= 5.0.1"
 requires "cssgrid >= 0.6.1"
 requires "chroma >= 0.2.7"

--- a/figuro/common/nodes/basics.nim
+++ b/figuro/common/nodes/basics.nim
@@ -48,8 +48,12 @@ type
     shadowSet
 
   FieldSet* = enum
-    # style attributes
-    # todo: this is hacky, but efficient
+    ## For tracking which fields have been set by the widget user code.
+    ## 
+    ## An example is setting `fill` in a button's code. We want this
+    ## to override any defaults the widget itself my later set.
+    ## 
+    ## TODO: this is hacky, but efficient
     fsZLevel
     fsRotation
     fsCornerRadius

--- a/figuro/common/nodes/ui.nim
+++ b/figuro/common/nodes/ui.nim
@@ -223,7 +223,7 @@ template connect*(
     b: Figuro,
     slot: typed,
     acceptVoidSlot: static bool = false,
-) =
+): void =
   ## template override
   when signalName(signal) == "doClick":
     a.listens.signals.incl {evClick, evClickOut}

--- a/figuro/common/nodes/ui.nim
+++ b/figuro/common/nodes/ui.nim
@@ -120,7 +120,7 @@ template toRef*(fig: FiguroWeakRef): auto =
 proc hash*(a: AppFrame): Hash =
   a.root.hash()
 
-proc new*[T: Figuro](tp: typedesc[T]): T =
+proc newFiguro*[T: Figuro](tp: typedesc[T]): T =
   result = T()
   result.debugId = nextAgentId()
   result.uid = result.debugId

--- a/figuro/meta/agents.nim
+++ b/figuro/meta/agents.nim
@@ -238,7 +238,7 @@ proc addAgentListeners*(obj: Agent,
                         sig: string,
                         tgt: Agent,
                         slot: AgentProc
-                        ) =
+                        ): void =
 
   # echo "add agent listener: ", sig, " obj: ", obj.debugId, " tgt: ", tgt.debugId
   # if obj.listeners.hasKey(sig):

--- a/figuro/meta/signals.nim
+++ b/figuro/meta/signals.nim
@@ -120,8 +120,8 @@ proc getSignalName*(signal: NimNode): NimNode =
     result = newStrLitNode signal.strVal
     # echo "getSignalName:result: ", result.treeRepr
 
-macro signalName*(signal: untyped): untyped =
-  result = getSignalName(signal)
+macro signalName*(signal: untyped): string =
+  getSignalName(signal)
 
 proc splitNamesImpl(slot: NimNode): Option[(NimNode, NimNode)] =
   # echo "splitNamesImpl: ", slot.treeRepr
@@ -161,7 +161,7 @@ macro signalType*(s: untyped): auto =
   for arg in obj[2..^1]:
     result.add arg[1]
 
-proc getAgentProcTy[T](tp: AgentProcTy[T]): T =
+proc getAgentProcTy*[T](tp: AgentProcTy[T]): T =
   discard
 
 template connect*[T](
@@ -170,7 +170,7 @@ template connect*[T](
     b: Agent,
     slot: Signal[T],
     acceptVoidSlot: static bool = false,
-) =
+): void =
   ## sets up `b` to recieve events from `a`. Both `a` and `b`
   ## must subtype `Agent`. The `signal` must be a signal proc, 
   ## while `slot` must be a slot proc.
@@ -196,8 +196,8 @@ template connect*[T](
               b, setValue)
       emit a.valueChanged(137) #=> prints "setValue! 137"
 
-  let agentSlot = slot
-  # static:
+  # let agentSlot: Signal[T] = slot
+  # # static:
   block:
     ## statically verify signal / slot types match
     # echo "TYP: ", repr typeof(SignalTypes.`signal`(typeof(a)))
@@ -207,7 +207,7 @@ template connect*[T](
       discard
     else:
       signalType = slotType
-  a.addAgentListeners(signalName(signal), b, agentSlot)
+  a.addAgentListeners(signalName(signal), b, slot)
 
 template connect*(
     a: Agent,
@@ -215,7 +215,7 @@ template connect*(
     b: Agent,
     slot: typed,
     acceptVoidSlot: static bool = false,
-) =
+): void =
   let agentSlot = `slot`(typeof(b))
   block:
     ## statically verify signal / slot types match

--- a/figuro/ui/apis.nim
+++ b/figuro/ui/apis.nim
@@ -7,8 +7,11 @@ import std/[hashes]
 
 import commons, core
 
+from std/sugar import capture
+
 export core, cssgrid, stack_strings
 export with
+export capture
 
 # template nodes*[T](fig: T, blk: untyped): untyped =
 #   ## begin drawing nodes

--- a/figuro/ui/apis.nim
+++ b/figuro/ui/apis.nim
@@ -89,13 +89,13 @@ proc boxFrom*(current: Figuro, x, y, w, h: float32) =
 #   ## Note: Experimental!
 #   nodeImpl(nkDrawable, id, inner)
 
-template rectangle*(id: static string, args: varargs[untyped]): untyped =
+template rectangle*(id: string, args: untyped): auto =
   ## Starts a new rectangle.
-  nodeImpl(nkRectangle, id, args)
+  widget[BasicFiguro](nkRectangle, id, args)
 
-template text*(id: string, inner: untyped): untyped =
+template text*(id: string, inner: untyped): auto =
   ## Starts a new rectangle.
-  nodeImpl(nkText, id, inner)
+  widget[BasicFiguro](nkText, id, args)
 
 ## ---------------------------------------------
 ##             Fidget Node APIs
@@ -475,15 +475,17 @@ proc gridTemplateDebugLines*(node: Figuro, grid: Figuro, color: Color = blueColo
       let w = grid.gridTemplate.columns[^1].start.UICoord
       let h = grid.gridTemplate.rows[^1].start.UICoord
       for col in grid.gridTemplate.columns[1..^2]:
-        rectangle "column", captures=col:
-          with node:
-            fill color
-            box ux(col.start.UICoord - wd), 0'ux, wd.ux(), h.ux()
+        capture col:
+          rectangle "column":
+            with node:
+              fill color
+              box ux(col.start.UICoord - wd), 0'ux, wd.ux(), h.ux()
       for row in grid.gridTemplate.rows[1..^2]:
-        rectangle "row", captures=row:
-          with node:
-            fill color
-            box 0, row.start.UICoord - wd, w.UICoord, wd
+        capture row:
+          rectangle "row":
+            with node:
+              fill color
+              box 0, row.start.UICoord - wd, w.UICoord, wd
       rectangle "edge":
         with node:
           fill color.darken(0.5)

--- a/figuro/ui/apis.nim
+++ b/figuro/ui/apis.nim
@@ -89,13 +89,13 @@ proc boxFrom*(current: Figuro, x, y, w, h: float32) =
 #   ## Note: Experimental!
 #   nodeImpl(nkDrawable, id, inner)
 
-template rectangle*(id: string, args: untyped): auto =
+template rectangle*(name: string, blk: untyped): auto =
   ## Starts a new rectangle.
-  widget[BasicFiguro](nkRectangle, id, args)
+  widget[BasicFiguro](nkRectangle, name, blk)
 
-template text*(id: string, inner: untyped): auto =
+template text*(name: string, blk: untyped): auto =
   ## Starts a new rectangle.
-  widget[BasicFiguro](nkText, id, args)
+  widget[BasicFiguro](nkText, name, blk)
 
 ## ---------------------------------------------
 ##             Fidget Node APIs

--- a/figuro/ui/core.nim
+++ b/figuro/ui/core.nim
@@ -303,10 +303,10 @@ template new*[F: ref object](
     name: string,
     blk: untyped
 ): auto =
-  when t.arity() in [0, 1]:
+  when arity(t) in [0, 1]:
     # non-generic type, note that arity(ref object) == 1
     widget[t](nkRectangle, name, blk)
-  elif t.arity() == stripGenericParams(t).typeof().arity():
+  elif arity(t) == stripGenericParams(t).typeof().arity():
     # partial generics, these are generics that aren't specified
     when stripGenericParams(t).typeof().arity() == 2:
       # partial generic, we'll provide empty tuple

--- a/figuro/ui/core.nim
+++ b/figuro/ui/core.nim
@@ -285,7 +285,7 @@ template setupWidget(
     when `hasBinds`:
       node
 
-template widget*[T](nkind: NodeKind = nkRectangle, blk: untyped): auto =
+template widget*[T](nkind: NodeKind = nkRectangle, name: string, blk: untyped): auto =
   ## sets up a new instance of a widget of type `T`.
   ##
   ## The args can include:
@@ -294,7 +294,7 @@ template widget*[T](nkind: NodeKind = nkRectangle, blk: untyped): auto =
   ##
   # widgetImpl(T, U, args)
   expandMacros:
-    setupWidget(T, nkind, "test",
+    setupWidget(T, nkind, name,
               false, false,
               (), node, blk)
 
@@ -305,17 +305,17 @@ template new*[F: ref object](
 ): auto =
   when t.arity() in [0, 1]:
     # non-generic type, note that arity(ref object) == 1
-    widget[t](nkRectangle, blk)
+    widget[t](nkRectangle, name, blk)
   elif t.arity() == stripGenericParams(t).typeof().arity():
     # partial generics, these are generics that aren't specified
     when stripGenericParams(t).typeof().arity() == 2:
       # partial generic, we'll provide empty tuple
-      widget[t[tuple[]]](nkRectangle, blk)
+      widget[t[tuple[]]](nkRectangle, name, blk)
     else:
       {.error: "only 1 generic params or less is supported".}
   else:
     # fully typed generics
-    widget[t](nkRectangle, blk)
+    widget[t](nkRectangle, name, blk)
 
 template exportWidget*[T](name: untyped, class: typedesc[T]): auto =
   ## exports `class` as a template `name`,
@@ -373,12 +373,6 @@ macro expose*(args: untyped): untyped =
         # echo "WID: args:post:\n", result.repr
   else:
     result = args
-
-macro nodeImpl*(kind: NodeKind, args: varargs[untyped]): untyped =
-  ## Base template for node, frame, rectangle...
-  let widget = ident("BasicFiguro")
-  let wargs = args.parseWidgetArgs()
-  result = widget.generateBodies(kind, nil, wargs, hasGeneric=false)
 
 proc computeScreenBox*(parent, node: Figuro, depth: int = 0) =
   ## Setups screenBoxes for the whole tree.

--- a/figuro/ui/core.nim
+++ b/figuro/ui/core.nim
@@ -361,9 +361,11 @@ template widget*[T, U](blk: untyped): auto =
               false, false,
               (), node, blk)
 
-template new*[F](t: typedesc[F], name: string = "node", blk: untyped): auto =
-  static:
-    echo "new widget: ", repr(t)
+template new*[F: ref object](
+    t: typedesc[F],
+    name: string,
+    blk: untyped
+): auto =
   when t.arity() in [0, 1]:
     # non-generic type, note that arity(ref object) == 1
     widget[F, NonGenericType](blk)

--- a/figuro/ui/core.nim
+++ b/figuro/ui/core.nim
@@ -278,6 +278,13 @@ template new*[F: ref object](
     name: string,
     blk: untyped
 ): auto =
+  ## Sets up a new widget instance and fills in
+  ## `tuple[]` for missing generics of the widget type.
+  ## 
+  ## E.g. if you have a `Button[T]` and you call
+  ## `Button.new` this template will change it to
+  ## `Button[tuple[]].new`.
+  ## 
   when arity(t) in [0, 1]:
     # non-generic type, note that arity(ref object) == 1
     widget[t](nkRectangle, name, blk)
@@ -286,14 +293,8 @@ template new*[F: ref object](
     when stripGenericParams(t).typeof().arity() == 2:
       # partial generic, we'll provide empty tuple
       widget[t[tuple[]]](nkRectangle, name, blk)
-    elif stripGenericParams(t).typeof().arity() == 3:
-      # partial generic, we'll provide empty tuple
-      widget[t[tuple[], tuple[]]](nkRectangle, name, blk)
-    elif stripGenericParams(t).typeof().arity() == 4:
-      # partial generic, we'll provide empty tuple
-      widget[t[tuple[], tuple[], tuple[]]](nkRectangle, name, blk)
     else:
-      {.error: "only 3 generic params or less is supported".}
+      {.error: "only 1 generic params or less is supported".}
   else:
     # fully typed generics
     widget[t](nkRectangle, name, blk)

--- a/figuro/ui/core.nim
+++ b/figuro/ui/core.nim
@@ -348,7 +348,7 @@ macro widgetImpl(class, gclass: untyped, args: varargs[untyped]): auto =
                           wargs, hasGeneric)
   echo "widgetImpl:\n", result.repr
 
-template widget*[T, U](blk: untyped): auto =
+template widget*[T](nkind: NodeKind = nkRectangle, blk: untyped): auto =
   ## sets up a new instance of a widget of type `T`.
   ##
   ## The args can include:
@@ -357,7 +357,7 @@ template widget*[T, U](blk: untyped): auto =
   ##
   # widgetImpl(T, U, args)
   expandMacros:
-    setupWidget(T, nkRectangle, "test",
+    setupWidget(T, nkind, "test",
               false, false,
               (), node, blk)
 
@@ -368,17 +368,17 @@ template new*[F: ref object](
 ): auto =
   when t.arity() in [0, 1]:
     # non-generic type, note that arity(ref object) == 1
-    widget[F, NonGenericType](blk)
+    widget[t](nkRectangle, blk)
   elif t.arity() == stripGenericParams(t).typeof().arity():
     # partial generics, these are generics that aren't specified
     when stripGenericParams(t).typeof().arity() == 2:
       # partial generic, we'll provide empty tuple
-      widget[t[tuple[]], (tuple[], )](blk)
+      widget[t[tuple[]]](nkRectangle, blk)
     else:
       {.error: "only 1 generic params or less is supported".}
   else:
     # fully typed generics
-    widget[t, genericParams(t)](blk)
+    widget[t](nkRectangle, blk)
 
 template exportWidget*[T](name: untyped, class: typedesc[T]): auto =
   ## exports `class` as a template `name`,

--- a/figuro/ui/core.nim
+++ b/figuro/ui/core.nim
@@ -286,8 +286,14 @@ template new*[F: ref object](
     when stripGenericParams(t).typeof().arity() == 2:
       # partial generic, we'll provide empty tuple
       widget[t[tuple[]]](nkRectangle, name, blk)
+    elif stripGenericParams(t).typeof().arity() == 3:
+      # partial generic, we'll provide empty tuple
+      widget[t[tuple[], tuple[]]](nkRectangle, name, blk)
+    elif stripGenericParams(t).typeof().arity() == 4:
+      # partial generic, we'll provide empty tuple
+      widget[t[tuple[], tuple[], tuple[]]](nkRectangle, name, blk)
     else:
-      {.error: "only 1 generic params or less is supported".}
+      {.error: "only 3 generic params or less is supported".}
   else:
     # fully typed generics
     widget[t](nkRectangle, name, blk)

--- a/figuro/ui/core.nim
+++ b/figuro/ui/core.nim
@@ -280,6 +280,8 @@ template setupWidget(
 ): auto =
   ## sets up a new instance of a widget
   block:
+    static:
+      echo "setupWidget: widgetType: ", widgetType.repr
     when not compiles(`parentName`.typeof):
       {.error: "no `node` variable defined in the current scope!".}
     let parent {.inject.}: Figuro = `parentName`
@@ -360,6 +362,8 @@ template widget*[T, U](blk: untyped): auto =
               (), node, blk)
 
 template new*[F](t: typedesc[F], name: string = "node", blk: untyped): auto =
+  static:
+    echo "new widget: ", repr(t)
   when t.arity() in [0, 1]:
     # non-generic type, note that arity(ref object) == 1
     widget[F, NonGenericType](blk)
@@ -367,12 +371,12 @@ template new*[F](t: typedesc[F], name: string = "node", blk: untyped): auto =
     # partial generics, these are generics that aren't specified
     when stripGenericParams(t).typeof().arity() == 2:
       # partial generic, we'll provide empty tuple
-      widget[stripGenericParams(t), (tuple[], )](blk)
+      widget[t[tuple[]], (tuple[], )](blk)
     else:
       {.error: "only 1 generic params or less is supported".}
   else:
     # fully typed generics
-    widget[stripGenericParams(t), genericParams(F)](blk)
+    widget[t, genericParams(t)](blk)
 
 template exportWidget*[T](name: untyped, class: typedesc[T]): auto =
   ## exports `class` as a template `name`,

--- a/figuro/ui/core.nim
+++ b/figuro/ui/core.nim
@@ -259,26 +259,19 @@ import utils, macros, typetraits
 template widget*[T](nkind: NodeKind = nkRectangle, name: string, blk: untyped): auto =
   ## sets up a new instance of a widget of type `T`.
   ##
-  ## The args can include:
-  ## - `captures(...)` captures a variable similar to the stdlib `capture` macro
-  ## - `state(U)` sets state type for Stateful widgets
-  ##
-  # widgetImpl(T, U, args)
-  expandMacros:
-    ## sets up a new instance of a widget
-    block:
-      when not compiles(node.typeof):
-        {.error: "no `node` variable defined in the current scope!".}
-      let parent {.inject.}: Figuro = `node`
-      var node {.inject.}: `T` = nil
-      preNode(`nkind`, `name`, node, parent)
-      node.preDraw = proc (c: Figuro) =
-        let node  {.inject.} = ## implicit variable in each widget block that references the current widget
-          `T`(c)
-        if preDrawReady in node.attrs:
-          node.attrs.excl preDrawReady
-          `blk`
-      postNode(Figuro(node))
+  block:
+    when not compiles(node.typeof):
+      {.error: "no `node` variable defined in the current scope!".}
+    let parent {.inject.}: Figuro = `node`
+    var node {.inject.}: `T` = nil
+    preNode(`nkind`, `name`, node, parent)
+    node.preDraw = proc (c: Figuro) =
+      let node  {.inject.} = ## implicit variable in each widget block that references the current widget
+        `T`(c)
+      if preDrawReady in node.attrs:
+        node.attrs.excl preDrawReady
+        `blk`
+    postNode(Figuro(node))
 
 template new*[F: ref object](
     t: typedesc[F],

--- a/figuro/ui/core.nim
+++ b/figuro/ui/core.nim
@@ -256,27 +256,15 @@ proc postNode*(node: var Figuro) =
 
 import utils, macros, typetraits
 
-type
-  NonGenericType = distinct void
-  EmptyType = distinct tuple[]
-
-macro hasGenericTypes*(n: typed): bool =
-  ## check is a given type is generic
-  var hasGenerics = true
-  if n.kind == nnkBracketExpr:
-    hasGenerics = true
-  else:
-    let impl = n.getImpl()
-    hasGenerics = impl[1].len() > 0
-  return newLit(hasGenerics)
-
 template setupWidget(
-    `widgetType`,`kind`, `id`;
-    `hasCaptures`,
-    `hasBinds`;
-    `capturedVals`,
-    `parentName`;
-    `blk`
+    widgetType,
+    nkind,
+    id;
+    hasCaptures,
+    hasBinds;
+    capturedVals,
+    parentName;
+    blk
 ): auto =
   ## sets up a new instance of a widget
   block:
@@ -286,7 +274,7 @@ template setupWidget(
       {.error: "no `node` variable defined in the current scope!".}
     let parent {.inject.}: Figuro = `parentName`
     var node {.inject.}: `widgetType` = nil
-    preNode(`kind`, `id`, node, parent)
+    preNode(`nkind`, `id`, node, parent)
     node.preDraw = proc (c: Figuro) =
       let node  {.inject.} = ## implicit variable in each widget block that references the current widget
         `widgetType`(c)
@@ -387,37 +375,15 @@ template exportWidget*[T](name: untyped, class: typedesc[T]): auto =
   ## the exported widget template can take standard widget args
   ## that `widget` can.
   ##
-  when class.hasGenericTypes():
-    template `name Of`*[U](args: varargs[untyped]): auto =
-      ## Instantiate a widget block for a given widget `T[U]`
-      ## creating a new Figuro node. This supports generic
-      ## widgets like `Button` which subtype `StatefulWidget[T]`.
-      ## 
-      ## Behind the scenes this creates a new block
-      ## with new `node` and `parent` variables.
-      ## The `node` variable becomes the new widget
-      ## instance.
-      widget[`T`, U](args)
-
-    template `name`*(args: varargs[untyped]): auto =
-      ## Instantiate a widget block for a given widget `T`
-      ## creating a new Figuro node.
-      ## 
-      ## Behind the scenes this creates a new block
-      ## with new `node` and `parent` variables.
-      ## The `node` variable becomes the new widget
-      ## instance.
-      widget[`T`, EmptyType](args)
-  else:
-    template `name`*(args: varargs[untyped]): auto =
-      ## Instantiate a widget block for a given widget `T`
-      ## creating a new Figuro node.
-      ##
-      ## Behind the scenes this creates a new block
-      ## with new `node` and `parent` variables.
-      ## The `node` variable becomes the new widget
-      ## instance.
-      widget[`T`, NonGenericType](args)
+  template `name`*(args: varargs[untyped]): auto =
+    ## Instantiate a widget block for a given widget `T`
+    ## creating a new Figuro node.
+    ##
+    ## Behind the scenes this creates a new block
+    ## with new `node` and `parent` variables.
+    ## The `node` variable becomes the new widget
+    ## instance.
+    widget[`T`](nkRectangle, args)
 
 {.hint[Name]:off.}
 template TemplateContents*[T](fig: T): untyped =

--- a/figuro/ui/core.nim
+++ b/figuro/ui/core.nim
@@ -89,7 +89,7 @@ proc removeExtraChildren*(node: Figuro) =
   node.children.setLen(node.diffIndex)
 
 proc refresh*(node: Figuro) =
-  ## Request the screen be redrawn
+  ## Request that the node and it's children be redrawn
   if node == nil:
     return
   # app.requestedFrame.inc

--- a/figuro/widgets/basics.nim
+++ b/figuro/widgets/basics.nim
@@ -20,3 +20,10 @@ proc draw*(self: Text) {.slot.} =
   self.kind = nkText
 
 # exportWidget(basicText, Text)
+
+template new*[F: Text](
+    t: typedesc[F],
+    name: string,
+    blk: untyped
+): auto =
+  widget[t](nkText, blk)

--- a/figuro/widgets/basics.nim
+++ b/figuro/widgets/basics.nim
@@ -26,4 +26,4 @@ template new*[F: Text](
     name: string,
     blk: untyped
 ): auto =
-  widget[t](nkText, blk)
+  widget[t](nkText, name, blk)

--- a/figuro/widgets/basics.nim
+++ b/figuro/widgets/basics.nim
@@ -4,10 +4,19 @@ import ../widget
 export widget
 
 type
-  Rectangle* = ref object of Figuro
+  Rectangle* = ref object of BasicFiguro
 
 proc draw*(self: Rectangle) {.slot.} =
   ## button widget!
   discard
 
-exportWidget(basicRectangles, Rectangle)
+# exportWidget(basicRectangle, Rectangle)
+
+type
+  Text* = ref object of BasicFiguro
+
+proc draw*(self: Text) {.slot.} =
+  ## text widget!
+  self.kind = nkText
+
+# exportWidget(basicText, Text)

--- a/figuro/widgets/input.nim
+++ b/figuro/widgets/input.nim
@@ -1,6 +1,7 @@
 import std/unicode
 
 import commons
+import basics
 import ../ui/utils
 import ../ui/textboxes
 
@@ -162,10 +163,11 @@ proc draw*(self: Input) {.slot.} =
       node.fill.a = self.value.toFloat * 1.0
 
     for i, selRect in self.text.selectionRects:
-      rectangle "selection", captures=[i]:
-        with node:
-          boxOf self.text.selectionRects[i]
-          fill css"#A0A0FF" * 0.4
+      capture i:
+        Rectangle.new "selection":
+          with node:
+            boxOf self.text.selectionRects[i]
+            fill css"#A0A0FF" * 0.4
 
   if self.disabled:
     fill node, whiteColor.darken(0.4)

--- a/tests/tanimate.nim
+++ b/tests/tanimate.nim
@@ -5,6 +5,8 @@ import figuro/widgets/button
 import figuro/widget
 import figuro
 
+import std/sugar
+
 type
   Main* = ref object of Figuro
     value: float
@@ -19,17 +21,18 @@ proc draw*(self: Main) {.slot.} =
     box node, 0'ui, 0'ui, 620'ui, 140'ui
     let j = 1
     for i in 0 .. 5:
-      Button.new "btn", captures=[i,j]:
-        let value = self.value
-        fill node, css"#AA0000"
-        node.onHover:
-          fill node, css"#F00000"
-        box node,
-            ux(20 + (i.toFloat + value) * 120),
-            ux(30 + 20 * sin(value + i.toFloat)),
-            60'ui, 60'ui
-        if i == 0:
-          node.fill.a = value * 1.0
+      Button.new "btn":
+        capture i, j:
+          let value = self.value
+          fill node, css"#AA0000"
+          node.onHover:
+            fill node, css"#F00000"
+          box node,
+              ux(20 + (i.toFloat + value) * 120),
+              ux(30 + 20 * sin(value + i.toFloat)),
+              60'ui, 60'ui
+          if i == 0:
+            node.fill.a = value * 1.0
 
 var fig = Main.new()
 

--- a/tests/tanimate.nim
+++ b/tests/tanimate.nim
@@ -17,7 +17,8 @@ proc tick*(self: Main, tick: int, now: MonoTime) {.slot.} =
   self.value = clamp(self.value mod 1.0, 0, 1.0)
 
 proc draw*(self: Main) {.slot.} =
-  rectangle "main", parent=self:
+  let node = self
+  rectangle "main":
     box node, 0'ui, 0'ui, 620'ui, 140'ui
     let j = 1
     for i in 0 .. 5:

--- a/tests/tanimate.nim
+++ b/tests/tanimate.nim
@@ -22,8 +22,8 @@ proc draw*(self: Main) {.slot.} =
     box node, 0'ui, 0'ui, 620'ui, 140'ui
     let j = 1
     for i in 0 .. 5:
-      Button.new "btn":
-        capture i, j:
+      capture i, j:
+        Button.new "btn":
           let value = self.value
           fill node, css"#AA0000"
           node.onHover:

--- a/tests/tbind.nim
+++ b/tests/tbind.nim
@@ -33,7 +33,7 @@ proc draw*(self: Main) {.slot.} =
         fill blackColor
         setText({font: $self.counter.value & " ₿" }, Center, Middle)
 
-  button "btnAdd":
+  Button.new "btnAdd":
     box node, 160'ux, 30'ux, 80'ux, 40'ux
     text "btnText":
       with node:
@@ -44,7 +44,7 @@ proc draw*(self: Main) {.slot.} =
     self.counter.onSignal(doButton) do(counter: Property[int]):
       counter.update(counter.value-1)
 
-  button "btnSub":
+  Button.new "btnSub":
     box node, 240'ux, 30'ux, 80'ux, 40'ux
     text "btnText":
       with node:

--- a/tests/tbutton.nim
+++ b/tests/tbutton.nim
@@ -29,7 +29,8 @@ proc draw*(self: Main) {.slot.} =
     fill css"#9F2B00"
     box 0'ux, 0'ux, 400'ux, 300'ux
 
-  Button[int].new "btn", parent=self:
+  let node = self
+  Button[int].new "btn":
     with node:
       box 40'ux, 30'ux, 80'ux, 80'ux
       fill css"#2B9F2B"

--- a/tests/tclick.nim
+++ b/tests/tclick.nim
@@ -1,7 +1,9 @@
-import figuro/widgets/[button, horizontal, basics]
+import figuro/widgets/[basics, button, horizontal, basics]
 import figuro/widget
 import figuro/ui/animations
 import figuro
+
+import std/sugar
 
 let
   typeface = loadTypeFace("IBMPlexSans-Regular.ttf")
@@ -61,20 +63,20 @@ proc draw*(self: Main) {.slot.} =
         itemWidth 100'ux, gap = 20'ui
         layoutItems justify=CxCenter, align=CxCenter
 
-      for i in 0 .. 4:
-        Button[int].new("btn", captures=i):
-          let btn = node
-          with node:
-            size 100'ux, 100'ux
-            cornerRadius 5.0
-            connect(doHover, self, btnHover)
-            connect(doClick, node, btnClicked)
-          if i == 0:
-            connect(self, update, node, btnTick)
-          Text.new "text":
+      for idx in 0 .. 4:
+          Button[int].new("btn"):
+            let btn = node
             with node:
-              fill blackColor
-              setText({font: $(btn.state)}, Center, Middle)
+              size 100'ux, 100'ux
+              cornerRadius 5.0
+              connect(doHover, self, btnHover)
+              connect(doClick, node, btnClicked)
+            if idx == 0:
+              connect(self, update, node, btnTick)
+            Text.new "text":
+              with node:
+                fill blackColor
+                setText({font: $(btn.state)}, Center, Middle)
 
 
 proc tick*(self: Main, tick: int, time: MonoTime) {.slot.} =

--- a/tests/tclick.nim
+++ b/tests/tclick.nim
@@ -1,5 +1,4 @@
-import figuro/widgets/button
-import figuro/widgets/horizontal
+import figuro/widgets/[button, horizontal, basics]
 import figuro/widget
 import figuro/ui/animations
 import figuro
@@ -45,7 +44,7 @@ proc draw*(self: Main) {.slot.} =
 
   # Calls the widget template `rectangle`.
   # This creates a new basic widget node. Generally used to draw generic rectangles.
-  rectangle "body":
+  Rectangle.new "body":
     with node:
       # sets the bounding box of this node
       box 10'ux, 10'ux, 600'ux, 120'ux
@@ -72,8 +71,7 @@ proc draw*(self: Main) {.slot.} =
             connect(doClick, node, btnClicked)
           if i == 0:
             connect(self, update, node, btnTick)
-
-          text "text":
+          Text.new "text":
             with node:
               fill blackColor
               setText({font: $(btn.state)}, Center, Middle)

--- a/tests/tdrag.nim
+++ b/tests/tdrag.nim
@@ -43,7 +43,8 @@ proc draw*(self: Main) {.slot.} =
     fill css"#9F2B00"
     box 0'ux, 0'ux, 400'ux, 300'ux
 
-  rectangle "btn", parent=self:
+  let node = self
+  rectangle "btn":
     with node:
       box 40'ux, 30'ux, 80'ux, 80'ux
       fill css"#2B9F2B"
@@ -56,7 +57,7 @@ proc draw*(self: Main) {.slot.} =
           fill blackColor
           setText({font: "drag me"})
 
-  Button[FadeAnimation].new "btn", parent=self:
+  Button[FadeAnimation].new "btn":
     echo "button:id: ", node.getId, " ", node.state.typeof
     with node:
       box 200'ux, 30'ux, 80'ux, 80'ux

--- a/tests/texample.nim
+++ b/tests/texample.nim
@@ -18,7 +18,9 @@ proc draw*(self: Main) {.slot.} =
   var node = self
   node.setName "root"
 
-  let vert = Vertical.new "vert":
+  var vert: Vertical
+  Vertical.new "vert":
+    vert = node
     with node:
       fill whiteColor.darken(0.5)
       offset 30'ux, 10'ux
@@ -28,16 +30,14 @@ proc draw*(self: Main) {.slot.} =
       fill blackColor * 0.1
       cornerRadius 20
 
-    let slider1 =
-      rectangle "slider":
+    rectangle "slider":
+      with node:
+        size 200'ux, 45'ux
+        fill css"#00A0AA"
+      text "txt1":
         with node:
-          size 200'ux, 45'ux
-          fill css"#00A0AA"
-        text "txt1":
-          with node:
-            setText({font: "test1"}, Center, Middle)
-            fill css"#FFFFFF"
-        result = node
+          setText({font: "test1"}, Center, Middle)
+          fill css"#FFFFFF"
     rectangle "slider":
       with node:
         size 0.5'fr, 0.5'fr
@@ -47,8 +47,8 @@ proc draw*(self: Main) {.slot.} =
         with node:
           setText({font: "test2"}, Center, Middle)
           fill css"#FFFFFF"
-    result = node
-  node.gridTemplateDebugLines Figuro(vert)
+  
+  node.gridTemplateDebugLines vert
 
 var main = Main.new()
 let frame = newAppFrame(main, size=(440'ui, 440'ui))

--- a/tests/texample.nim
+++ b/tests/texample.nim
@@ -18,7 +18,7 @@ proc draw*(self: Main) {.slot.} =
   var node = self
   node.setName "root"
 
-  let vert = vertical "vert":
+  let vert = Vertical.new "vert":
     with node:
       fill whiteColor.darken(0.5)
       offset 30'ux, 10'ux

--- a/tests/tfade.nim
+++ b/tests/tfade.nim
@@ -18,7 +18,8 @@ proc buttonHover*(self: Main, evtKind: EventKind) {.slot.} =
   refresh(self)
 
 proc draw*(self: Main) {.slot.} =
-  rectangle "body", parent=self:
+  let node = self
+  rectangle "body":
     with node:
       box 10'ux, 10'ux, 600'ux, 120'ux
       cornerRadius 10.0

--- a/tests/tfade.nim
+++ b/tests/tfade.nim
@@ -5,6 +5,8 @@ import figuro/ui/animations
 import figuro/widget
 import figuro
 
+import sugar
+
 type
   Main* = ref object of Figuro
     bkgFade* = FadeAnimation(minMax: 0.0..0.15,
@@ -21,13 +23,14 @@ proc draw*(self: Main) {.slot.} =
       box 10'ux, 10'ux, 600'ux, 120'ux
       cornerRadius 10.0
       fill whiteColor.darken(self.bkgFade.amount)
-    horizontal "horiz":
+    Horizontal.new "horiz":
       offset node, 10'ux, 0'ux
       itemWidth node, cx"min-content", gap = 20'ui
       for i in 0 .. 4:
-        button "btn", captures=i:
-          size node, 100'ux, 100'ux
-          connect(node, doHover, self, buttonHover)
+        capture i:
+          Button.new "btn":
+            size node, 100'ux, 100'ux
+            connect(node, doHover, self, buttonHover)
 
 proc tick*(self: Main, tick: int, now: MonoTime) {.slot.} =
   self.bkgFade.tick(self)

--- a/tests/tfadeAlt.nim
+++ b/tests/tfadeAlt.nim
@@ -34,11 +34,12 @@ proc draw*(self: Main) {.slot.} =
       offset node, 10'ux, 0'ux
       itemWidth node, cx"min-content", gap = 20'ui
       for i in 0 .. 4:
-        Button[int].new "btn", captures=i:
-          with node:
-            size 100'ux, 100'ux
-            # we need to connect the nodes onHover event
-            connect(doHover, self, buttonHover)
+        capture i:
+          Button[int].new "btn":
+            with node:
+              size 100'ux, 100'ux
+              # we need to connect the nodes onHover event
+              connect(doHover, self, buttonHover)
 
 var main = Main.new()
 let frame = newAppFrame(main, size=(720'ui, 140'ui))

--- a/tests/tgrid.nim
+++ b/tests/tgrid.nim
@@ -59,7 +59,7 @@ proc draw*(self: GridApp) {.slot.} =
         gridRow "middle" // "bottom"
         gridColumn "button-la" // "button-lb"
 
-      button "btn":
+      Button.new "btn":
         with node:
           # label fmt"Clicked1: {self.count:4d}"
           # size 100'ux, 30'ux
@@ -69,7 +69,7 @@ proc draw*(self: GridApp) {.slot.} =
         # onClick:
         #   self.count.inc()
 
-    button "grid":
+    Button.new "grid":
       with node:
         gridRow "middle" // "bottom"
         gridColumn "button-ra" // "button-rb"

--- a/tests/tgridautoflow.nim
+++ b/tests/tgridautoflow.nim
@@ -45,12 +45,13 @@ proc draw*(self: GridApp) {.slot.} =
           fill rgba(245, 129, 49, 123).to(Color)
 
       for i in 1..4:
-        rectangle "items b", captures=i:
-          # Setup CSS Grid Template
-          with node:
-            cornerRadius 6
-            # some color stuff
-            fill rgba(66, 177, 44, 167).to(Color).spin(i.toFloat*50)
+        capture i:
+          rectangle "items b":
+            # Setup CSS Grid Template
+            with node:
+              cornerRadius 6
+              # some color stuff
+              fill rgba(66, 177, 44, 167).to(Color).spin(i.toFloat*50)
 
       rectangle "item e":
         # Setup CSS Grid Template

--- a/tests/tlayers.nim
+++ b/tests/tlayers.nim
@@ -41,18 +41,18 @@ proc draw*(self: Main) {.slot.} =
         fill blackColor
         setText({font: "not clipped"})
 
-    button "btn":
+    Button.new "btn":
       with node:
         box 10'pp, 15'pp, 130'pp, 20'pp
         zlevel 20.ZLevel
         setLabel(node.zlevel, left=true)
 
-    button "btn":
+    Button.new "btn":
       with node:
         box 10'pp, 45'pp, 130'pp, 20'pp
         setLabel(node.zlevel, left=true)
 
-    button "btn":
+    Button.new "btn":
       with node:
         box 10'pp, 75'pp, 130'pp, 20'pp
         zlevel -5.ZLevel
@@ -70,18 +70,18 @@ proc draw*(self: Main) {.slot.} =
         fill blackColor
         setText({font: "clipped"})
 
-    button "btn":
+    Button.new "btn":
       with node:
         box 10'pp, 15'pp, 130'pp, 20'pp
         zlevel 20.ZLevel
         setLabel(node.zlevel, left=true)
 
-    button "btn":
+    Button.new "btn":
       with node:
         box 10'pp, 45'pp, 130'pp, 20'pp
         setLabel(node.zlevel, left=true)
 
-    button "btn":
+    Button.new "btn":
       with node:
         box 10'pp, 75'pp, 130'pp, 20'pp
         zlevel -5.ZLevel

--- a/tests/tminimal.nim
+++ b/tests/tminimal.nim
@@ -4,6 +4,8 @@ import figuro/widgets/[button, basics]
 import figuro/widget
 import figuro
 
+import std/sugar
+
 type
   Main* = ref object of Figuro
     value: float
@@ -24,10 +26,12 @@ proc draw*(self: Main) {.slot.} =
         box 10'pp, 60'pp, 80'pp, 10'pp
         fill css"#2B9FEA"
 
-    Button.new "btn":
-      with node:
-        box 10'pp, 10'pp, 80'pp, 10'pp
-        fill css"#2B9FEA"
+    for i in 1..2:
+      capture i:
+        Button.new "btn":
+          with node:
+            box 10'pp, UICoord(40 * i + 10), 80'pp, 10'pp
+            fill css"#2B9FEA"
 
 
 var main = Main.new()

--- a/tests/tminimal.nim
+++ b/tests/tminimal.nim
@@ -19,15 +19,16 @@ proc draw*(self: Main) {.slot.} =
       box 10'pp, 10'pp, 80'pp, 80'pp
       cornerRadius 10.0'ui
 
+    Button[int].new "btn":
+      with node:
+        box 10'pp, 60'pp, 80'pp, 10'pp
+        fill css"#2B9FEA"
+
     Button.new "btn":
       with node:
         box 10'pp, 10'pp, 80'pp, 10'pp
         fill css"#2B9FEA"
 
-    Button[int].new "btn":
-      with node:
-        box 10'pp, 60'pp, 80'pp, 10'pp
-        fill css"#2B9FEA"
 
 var main = Main.new()
 let frame = newAppFrame(main, size=(400'ui, 400'ui))

--- a/tests/tscroll.nim
+++ b/tests/tscroll.nim
@@ -32,14 +32,15 @@ proc draw*(self: Main) {.slot.} =
           offset 10'ux, 10'ux
           itemHeight cx"max-content"
         for i in 0 .. 15:
-          Button.new "button", captures=[i]:
-            # current.gridItem = nil
-            with node:
-              size 1'fr, 50'ux
-              fill rgba(66, 177, 44, 197).to(Color).spin(i.toFloat*50)
-            if i in [3, 7]:
-              node.size 0.9'fr, 120'ux
-            node.connect(doHover, self, Main.hover)
+          capture i:
+            Button.new "button":
+              # current.gridItem = nil
+              with node:
+                size 1'fr, 50'ux
+                fill rgba(66, 177, 44, 197).to(Color).spin(i.toFloat*50)
+              if i in [3, 7]:
+                node.size 0.9'fr, 120'ux
+              node.connect(doHover, self, Main.hover)
 
 var main = Main.new()
 let frame = newAppFrame(main, size=(600'ui, 480'ui))

--- a/tests/tscroll.nim
+++ b/tests/tscroll.nim
@@ -7,6 +7,7 @@ import figuro/widget
 import figuro
 
 import std/sugar
+import std/macros
 
 type
   Main* = ref object of Figuro
@@ -15,7 +16,9 @@ type
 
 proc hover*(self: Main, kind: EventKind) {.slot.} =
   self.hasHovered = kind == Enter
+  echo "hover: ", kind
   refresh(self)
+
 
 proc draw*(self: Main) {.slot.} =
   var node = self
@@ -34,7 +37,6 @@ proc draw*(self: Main) {.slot.} =
           offset 10'ux, 10'ux
           itemHeight cx"max-content"
         for idx in 0 .. 15:
-          capture idx:
             Button.new "button":
               # current.gridItem = nil
               with node:
@@ -42,7 +44,7 @@ proc draw*(self: Main) {.slot.} =
                 fill rgba(66, 177, 44, 197).to(Color).spin(idx.toFloat*50)
               if idx in [3, 7]:
                 node.size 0.9'fr, 120'ux
-              # node.connect(doHover, self, Main.hover)
+              connect(node, doHover, self, Main.hover)
 
 var main = Main.new()
 let frame = newAppFrame(main, size=(600'ui, 480'ui))

--- a/tests/tscroll.nim
+++ b/tests/tscroll.nim
@@ -19,6 +19,15 @@ proc hover*(self: Main, kind: EventKind) {.slot.} =
   echo "hover: ", kind
   refresh(self)
 
+proc buttonItem(self, node: Figuro, idx: int) =
+  Button.new "button":
+    # current.gridItem = nil
+    with node:
+      size 1'fr, 50'ux
+      fill rgba(66, 177, 44, 197).to(Color).spin(idx.toFloat*50)
+    if idx in [3, 7]:
+      node.size 0.9'fr, 120'ux
+    connect(node, doHover, self, Main.hover)
 
 proc draw*(self: Main) {.slot.} =
   var node = self
@@ -37,14 +46,7 @@ proc draw*(self: Main) {.slot.} =
           offset 10'ux, 10'ux
           itemHeight cx"max-content"
         for idx in 0 .. 15:
-            Button.new "button":
-              # current.gridItem = nil
-              with node:
-                size 1'fr, 50'ux
-                fill rgba(66, 177, 44, 197).to(Color).spin(idx.toFloat*50)
-              if idx in [3, 7]:
-                node.size 0.9'fr, 120'ux
-              connect(node, doHover, self, Main.hover)
+          buttonItem(self, node, idx)
 
 var main = Main.new()
 let frame = newAppFrame(main, size=(600'ui, 480'ui))

--- a/tests/tscroll.nim
+++ b/tests/tscroll.nim
@@ -6,6 +6,8 @@ import figuro/widgets/vertical
 import figuro/widget
 import figuro
 
+import std/sugar
+
 type
   Main* = ref object of Figuro
     value: float
@@ -31,16 +33,16 @@ proc draw*(self: Main) {.slot.} =
         with node:
           offset 10'ux, 10'ux
           itemHeight cx"max-content"
-        for i in 0 .. 15:
-          capture i:
+        for idx in 0 .. 15:
+          capture idx:
             Button.new "button":
               # current.gridItem = nil
               with node:
                 size 1'fr, 50'ux
-                fill rgba(66, 177, 44, 197).to(Color).spin(i.toFloat*50)
-              if i in [3, 7]:
+                fill rgba(66, 177, 44, 197).to(Color).spin(idx.toFloat*50)
+              if idx in [3, 7]:
                 node.size 0.9'fr, 120'ux
-              node.connect(doHover, self, Main.hover)
+              # node.connect(doHover, self, Main.hover)
 
 var main = Main.new()
 let frame = newAppFrame(main, size=(600'ui, 480'ui))


### PR DESCRIPTION
- build node api on `Figuro.new` api syntax
- replace macros with templates
- new api looses support for things:
  - removes `captures=[x,y,z]` notation in favor of just using `std/sugar.capture`
  - removes `parent=x` helper api
  - removes `result = node` to indicate returning a node


 