### PR TITLE
Eliminated cstring warnings

### DIFF
--- a/src/figuro/renderer/opengl/shaders.nim
+++ b/src/figuro/renderer/opengl/shaders.nim
@@ -151,7 +151,7 @@ proc readAttribsAndUniforms(shader: Shader) =
         length.addr,
         size.addr,
         kind.addr,
-        cast[cstring](buf[0].addr),
+        cstring(buf),
       )
       buf.setLen(length)
 
@@ -174,7 +174,7 @@ proc readAttribsAndUniforms(shader: Shader) =
         length.addr,
         size.addr,
         kind.addr,
-        cast[cstring](buf[0].addr),
+        cstring(buf),
       )
       buf.setLen(length)
 

--- a/src/figuro/renderer/opengl/shaders.nim
+++ b/src/figuro/renderer/opengl/shaders.nim
@@ -32,7 +32,7 @@ proc getErrorLog*(
   var length: GLint = 0
   lenProc(id, GL_INFO_LOG_LENGTH, length.addr)
   var log = newString(length.int)
-  strProc(id, length, nil, log)
+  strProc(id, length, nil, cstring(log))
   when defined(emscripten):
     result = log
   else:
@@ -151,11 +151,11 @@ proc readAttribsAndUniforms(shader: Shader) =
         length.addr,
         size.addr,
         kind.addr,
-        buf[0].addr,
+        cast[cstring](buf[0].addr),
       )
       buf.setLen(length)
 
-      let location = glGetAttribLocation(shader.programId, buf)
+      let location = glGetAttribLocation(shader.programId, cstring(buf))
       shader.attribs.add(ShaderAttrib(name: move(buf), location: location))
 
   block uniforms:
@@ -174,7 +174,7 @@ proc readAttribsAndUniforms(shader: Shader) =
         length.addr,
         size.addr,
         kind.addr,
-        buf[0].addr,
+        cast[cstring](buf[0].addr),
       )
       buf.setLen(length)
 
@@ -182,7 +182,7 @@ proc readAttribsAndUniforms(shader: Shader) =
         # Skip arrays, these are part of UBOs and done a different way
         continue
 
-      let location = glGetUniformLocation(shader.programId, buf)
+      let location = glGetUniformLocation(shader.programId, cstring(buf))
       shader.uniforms.add(Uniform(name: move(buf), location: location))
 
 proc newShader*(compute: (string, string)): Shader =


### PR DESCRIPTION
This eliminates the warnings. My understanding is that these different approaches are needed for converting `ptr -> cstring` verus `string -> cstring`. Is that correct?